### PR TITLE
feat: truely support generic lists

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -541,31 +541,7 @@ module.exports = grammar({
                 ),
 
                 repeat(
-                    choice(
-                        $.unordered_link2,
-                        $.unordered_link3,
-                        $.unordered_link4,
-                        $.unordered_link5,
-                        $.unordered_link6,
-
-                        $.ordered_link2,
-                        $.ordered_link3,
-                        $.ordered_link4,
-                        $.ordered_link5,
-                        $.ordered_link6,
-
-                        $.unordered_list2,
-                        $.unordered_list3,
-                        $.unordered_list4,
-                        $.unordered_list5,
-                        $.unordered_list6,
-
-                        $.ordered_list2,
-                        $.ordered_list3,
-                        $.ordered_list4,
-                        $.ordered_list5,
-                        $.ordered_list6,
-                    )
+                    $._any_list_item_level_2,
                 )
             )
         ),
@@ -591,27 +567,7 @@ module.exports = grammar({
                 ),
 
                 repeat(
-                    choice(
-                        $.unordered_link3,
-                        $.unordered_link4,
-                        $.unordered_link5,
-                        $.unordered_link6,
-
-                        $.ordered_link3,
-                        $.ordered_link4,
-                        $.ordered_link5,
-                        $.ordered_link6,
-
-                        $.unordered_list3,
-                        $.unordered_list4,
-                        $.unordered_list5,
-                        $.unordered_list6,
-
-                        $.ordered_list3,
-                        $.ordered_list4,
-                        $.ordered_list5,
-                        $.ordered_list6,
-                    )
+                    $._any_list_item_level_3,
                 )
             )
         ),
@@ -637,23 +593,7 @@ module.exports = grammar({
                 ),
 
                 repeat(
-                    choice(
-                        $.unordered_link4,
-                        $.unordered_link5,
-                        $.unordered_link6,
-
-                        $.ordered_link4,
-                        $.ordered_link5,
-                        $.ordered_link6,
-
-                        $.unordered_list4,
-                        $.unordered_list5,
-                        $.unordered_list6,
-
-                        $.ordered_list4,
-                        $.ordered_list5,
-                        $.ordered_list6,
-                    )
+                    $._any_list_item_level_4,
                 )
             )
         ),
@@ -679,19 +619,7 @@ module.exports = grammar({
                 ),
 
                 repeat(
-                    choice(
-                        $.unordered_link5,
-                        $.unordered_link6,
-
-                        $.ordered_link5,
-                        $.ordered_link6,
-
-                        $.unordered_list5,
-                        $.unordered_list6,
-
-                        $.ordered_list5,
-                        $.ordered_list6,
-                    )
+                    $._any_list_item_level_5,
                 )
             )
         ),
@@ -717,13 +645,7 @@ module.exports = grammar({
                 ),
 
                 repeat(
-                    choice(
-                        $.unordered_link6,
-                        $.ordered_link6,
-
-                        $.unordered_list6,
-                        $.ordered_list6,
-                    )
+                    $._any_list_item_level_6,
                 )
             )
         ),
@@ -771,31 +693,7 @@ module.exports = grammar({
                 ),
 
                 repeat(
-                    choice(
-                        $.unordered_link2,
-                        $.unordered_link3,
-                        $.unordered_link4,
-                        $.unordered_link5,
-                        $.unordered_link6,
-
-                        $.ordered_link2,
-                        $.ordered_link3,
-                        $.ordered_link4,
-                        $.ordered_link5,
-                        $.ordered_link6,
-
-                        $.unordered_list2,
-                        $.unordered_list3,
-                        $.unordered_list4,
-                        $.unordered_list5,
-                        $.unordered_list6,
-
-                        $.ordered_list2,
-                        $.ordered_list3,
-                        $.ordered_list4,
-                        $.ordered_list5,
-                        $.ordered_list6,
-                    )
+                    $._any_list_item_level_2,
                 )
             )
         ),
@@ -821,27 +719,7 @@ module.exports = grammar({
                 ),
 
                 repeat(
-                    choice(
-                        $.unordered_link3,
-                        $.unordered_link4,
-                        $.unordered_link5,
-                        $.unordered_link6,
-
-                        $.ordered_link3,
-                        $.ordered_link4,
-                        $.ordered_link5,
-                        $.ordered_link6,
-
-                        $.unordered_list3,
-                        $.unordered_list4,
-                        $.unordered_list5,
-                        $.unordered_list6,
-
-                        $.ordered_list3,
-                        $.ordered_list4,
-                        $.ordered_list5,
-                        $.ordered_list6,
-                    )
+                    $._any_list_item_level_3,
                 )
             )
         ),
@@ -867,23 +745,7 @@ module.exports = grammar({
                 ),
 
                 repeat(
-                    choice(
-                        $.unordered_link4,
-                        $.unordered_link5,
-                        $.unordered_link6,
-
-                        $.ordered_link4,
-                        $.ordered_link5,
-                        $.ordered_link6,
-
-                        $.unordered_list4,
-                        $.unordered_list5,
-                        $.unordered_list6,
-
-                        $.ordered_list4,
-                        $.ordered_list5,
-                        $.ordered_list6,
-                    )
+                    $._any_list_item_level_4,
                 )
             )
         ),
@@ -909,19 +771,7 @@ module.exports = grammar({
                 ),
 
                 repeat(
-                    choice(
-                        $.unordered_link5,
-                        $.unordered_link6,
-
-                        $.ordered_link5,
-                        $.ordered_link6,
-
-                        $.unordered_list5,
-                        $.unordered_list6,
-
-                        $.ordered_list5,
-                        $.ordered_list6,
-                    )
+                    $._any_list_item_level_5,
                 )
             )
         ),
@@ -947,13 +797,7 @@ module.exports = grammar({
                 ),
 
                 repeat(
-                    choice(
-                        $.unordered_link6,
-                        $.ordered_link6,
-
-                        $.unordered_list6,
-                        $.ordered_list6,
-                    )
+                    $._any_list_item_level_6,
                 )
             )
         ),
@@ -1364,46 +1208,70 @@ module.exports = grammar({
             )
         ),
 
+        _any_list_item_level_1: $ =>
+        choice(
+            $.unordered_list1,
+            $.ordered_list1,
+            $.todo_item1,
+            $.unordered_link1,
+            $.ordered_link1,
+            $._any_list_item_level_2,
+        ),
+
+        _any_list_item_level_2: $ =>
+        choice(
+            $.unordered_list2,
+            $.ordered_list2,
+            $.todo_item2,
+            $.unordered_link2,
+            $.ordered_link2,
+            $._any_list_item_level_3,
+        ),
+
+        _any_list_item_level_3: $ =>
+        choice(
+            $.unordered_list3,
+            $.ordered_list3,
+            $.todo_item3,
+            $.unordered_link3,
+            $.ordered_link3,
+            $._any_list_item_level_4,
+        ),
+
+        _any_list_item_level_4: $ =>
+        choice(
+            $.unordered_list4,
+            $.ordered_list4,
+            $.todo_item4,
+            $.unordered_link4,
+            $.ordered_link4,
+            $._any_list_item_level_5,
+        ),
+
+        _any_list_item_level_5: $ =>
+        choice(
+            $.unordered_list5,
+            $.ordered_list5,
+            $.todo_item5,
+            $.unordered_link5,
+            $.ordered_link5,
+            $._any_list_item_level_6,
+        ),
+
+        _any_list_item_level_6: $ =>
+        choice(
+            $.unordered_list6,
+            $.ordered_list6,
+            $.todo_item6,
+            $.unordered_link6,
+            $.ordered_link6,
+        ),
+
         // TODO: complete docs
         generic_list: $ =>
         prec.right(0,
             repeat1(
-                choice(
-                    $.unordered_list1,
-                    $.unordered_list2,
-                    $.unordered_list3,
-                    $.unordered_list4,
-                    $.unordered_list5,
-                    $.unordered_list6,
-
-                    $.ordered_list1,
-                    $.ordered_list2,
-                    $.ordered_list3,
-                    $.ordered_list4,
-                    $.ordered_list5,
-                    $.ordered_list6,
-
-                    $.todo_item1,
-                    $.todo_item2,
-                    $.todo_item3,
-                    $.todo_item4,
-                    $.todo_item5,
-                    $.todo_item6,
-
-                    $.unordered_link1,
-                    $.unordered_link2,
-                    $.unordered_link3,
-                    $.unordered_link4,
-                    $.unordered_link5,
-                    $.unordered_link6,
-
-                    $.ordered_link1,
-                    $.ordered_link2,
-                    $.ordered_link3,
-                    $.ordered_link4,
-                    $.ordered_link5,
-                    $.ordered_link6,
-                )
+                $._any_list_item_level_1,
             )
         ),
 
@@ -1418,37 +1286,7 @@ module.exports = grammar({
                 ),
 
                 repeat(
-                    choice(
-                        $.todo_item2,
-                        $.todo_item3,
-                        $.todo_item4,
-                        $.todo_item5,
-                        $.todo_item6,
-
-                        $.unordered_list2,
-                        $.unordered_list3,
-                        $.unordered_list4,
-                        $.unordered_list5,
-                        $.unordered_list6,
-
-                        $.ordered_list2,
-                        $.ordered_list3,
-                        $.ordered_list4,
-                        $.ordered_list5,
-                        $.ordered_list6,
-
-                        $.unordered_link2,
-                        $.unordered_link3,
-                        $.unordered_link4,
-                        $.unordered_link5,
-                        $.unordered_link6,
-
-                        $.ordered_link2,
-                        $.ordered_link3,
-                        $.ordered_link4,
-                        $.ordered_link5,
-                        $.ordered_link6,
-                    )
+                    $._any_list_item_level_2,
                 )
             )
         ),
@@ -1464,32 +1302,7 @@ module.exports = grammar({
                 ),
 
                 repeat(
-                    choice(
-                        $.todo_item3,
-                        $.todo_item4,
-                        $.todo_item5,
-                        $.todo_item6,
-
-                        $.unordered_list3,
-                        $.unordered_list4,
-                        $.unordered_list5,
-                        $.unordered_list6,
-
-                        $.ordered_list3,
-                        $.ordered_list4,
-                        $.ordered_list5,
-                        $.ordered_list6,
-
-                        $.unordered_link3,
-                        $.unordered_link4,
-                        $.unordered_link5,
-                        $.unordered_link6,
-
-                        $.ordered_link3,
-                        $.ordered_link4,
-                        $.ordered_link5,
-                        $.ordered_link6,
-                    )
+                    $._any_list_item_level_3,
                 )
             )
         ),
@@ -1505,27 +1318,7 @@ module.exports = grammar({
                 ),
 
                 repeat(
-                    choice(
-                        $.todo_item4,
-                        $.todo_item5,
-                        $.todo_item6,
-
-                        $.unordered_list4,
-                        $.unordered_list5,
-                        $.unordered_list6,
-
-                        $.ordered_list4,
-                        $.ordered_list5,
-                        $.ordered_list6,
-
-                        $.unordered_link4,
-                        $.unordered_link5,
-                        $.unordered_link6,
-
-                        $.ordered_link4,
-                        $.ordered_link5,
-                        $.ordered_link6,
-                    )
+                    $._any_list_item_level_4,
                 )
             )
         ),
@@ -1541,22 +1334,7 @@ module.exports = grammar({
                 ),
 
                 repeat(
-                    choice(
-                        $.todo_item5,
-                        $.todo_item6,
-
-                        $.unordered_list5,
-                        $.unordered_list6,
-
-                        $.ordered_list5,
-                        $.ordered_list6,
-
-                        $.unordered_link5,
-                        $.unordered_link6,
-
-                        $.ordered_link5,
-                        $.ordered_link6,
-                    )
+                    $._any_list_item_level_5,
                 )
             )
         ),
@@ -1572,13 +1350,7 @@ module.exports = grammar({
                 ),
 
                 repeat(
-                    choice(
-                        $.todo_item6,
-                        $.unordered_list6,
-                        $.ordered_list6,
-                        $.unordered_link6,
-                        $.ordered_link6,
-                    )
+                    $._any_list_item_level_6,
                 )
             )
         ),
@@ -1606,37 +1378,7 @@ module.exports = grammar({
                 ),
 
                 repeat(
-                    choice(
-                        $.todo_item2,
-                        $.todo_item3,
-                        $.todo_item4,
-                        $.todo_item5,
-                        $.todo_item6,
-
-                        $.unordered_list2,
-                        $.unordered_list3,
-                        $.unordered_list4,
-                        $.unordered_list5,
-                        $.unordered_list6,
-
-                        $.ordered_list2,
-                        $.ordered_list3,
-                        $.ordered_list4,
-                        $.ordered_list5,
-                        $.ordered_list6,
-
-                        $.unordered_link2,
-                        $.unordered_link3,
-                        $.unordered_link4,
-                        $.unordered_link5,
-                        $.unordered_link6,
-
-                        $.ordered_link2,
-                        $.ordered_link3,
-                        $.ordered_link4,
-                        $.ordered_link5,
-                        $.ordered_link6,
-                    )
+                    $._any_list_item_level_2,
                 )
             )
         ),
@@ -1652,32 +1394,7 @@ module.exports = grammar({
                 ),
 
                 repeat(
-                    choice(
-                        $.todo_item3,
-                        $.todo_item4,
-                        $.todo_item5,
-                        $.todo_item6,
-
-                        $.unordered_list3,
-                        $.unordered_list4,
-                        $.unordered_list5,
-                        $.unordered_list6,
-
-                        $.ordered_list3,
-                        $.ordered_list4,
-                        $.ordered_list5,
-                        $.ordered_list6,
-
-                        $.unordered_link3,
-                        $.unordered_link4,
-                        $.unordered_link5,
-                        $.unordered_link6,
-
-                        $.ordered_link3,
-                        $.ordered_link4,
-                        $.ordered_link5,
-                        $.ordered_link6,
-                    )
+                    $._any_list_item_level_3,
                 )
             )
         ),
@@ -1693,27 +1410,7 @@ module.exports = grammar({
                 ),
 
                 repeat(
-                    choice(
-                        $.todo_item4,
-                        $.todo_item5,
-                        $.todo_item6,
-
-                        $.unordered_list4,
-                        $.unordered_list5,
-                        $.unordered_list6,
-
-                        $.ordered_list4,
-                        $.ordered_list5,
-                        $.ordered_list6,
-
-                        $.unordered_link4,
-                        $.unordered_link5,
-                        $.unordered_link6,
-
-                        $.ordered_link4,
-                        $.ordered_link5,
-                        $.ordered_link6,
-                    )
+                    $._any_list_item_level_4,
                 )
             )
         ),
@@ -1729,22 +1426,7 @@ module.exports = grammar({
                 ),
 
                 repeat(
-                    choice(
-                        $.todo_item5,
-                        $.todo_item6,
-
-                        $.unordered_list5,
-                        $.unordered_list6,
-
-                        $.ordered_list5,
-                        $.ordered_list6,
-
-                        $.unordered_link5,
-                        $.unordered_link6,
-
-                        $.ordered_link5,
-                        $.ordered_link6,
-                    )
+                    $._any_list_item_level_5,
                 )
             )
         ),
@@ -1760,13 +1442,7 @@ module.exports = grammar({
                 ),
 
                 repeat(
-                    choice(
-                        $.todo_item6,
-                        $.unordered_list6,
-                        $.ordered_list6,
-                        $.unordered_link6,
-                        $.ordered_link6,
-                    )
+                    $._any_list_item_level_6,
                 )
             )
         ),
@@ -1815,6 +1491,18 @@ module.exports = grammar({
         ),
 
         // --------------------------------------------------
+        _any_todo_state: $ =>
+        choice(
+            $.todo_item_undone,
+            $.todo_item_pending,
+            $.todo_item_done,
+            $.todo_item_on_hold,
+            $.todo_item_cancelled,
+            $.todo_item_urgent,
+            $.todo_item_uncertain,
+            $.todo_item_recurring,
+        ),
+
         todo_item1: $ =>
         prec.right(0,
             seq(
@@ -1822,17 +1510,7 @@ module.exports = grammar({
 
                 field(
                     "state",
-
-                    choice(
-                        $.todo_item_undone,
-                        $.todo_item_pending,
-                        $.todo_item_done,
-                        $.todo_item_on_hold,
-                        $.todo_item_cancelled,
-                        $.todo_item_urgent,
-                        $.todo_item_uncertain,
-                        $.todo_item_recurring,
-                    ),
+                    $._any_todo_state,
                 ),
 
                 token.immediate(/\s+/),
@@ -1843,13 +1521,7 @@ module.exports = grammar({
                 ),
 
                 repeat(
-                    choice(
-                        $.todo_item2,
-                        $.todo_item3,
-                        $.todo_item4,
-                        $.todo_item5,
-                        $.todo_item6,
-                    ),
+                    $._any_list_item_level_2,
                 ),
             )
         ),
@@ -1861,17 +1533,7 @@ module.exports = grammar({
 
                 field(
                     "state",
-
-                    choice(
-                        $.todo_item_undone,
-                        $.todo_item_pending,
-                        $.todo_item_done,
-                        $.todo_item_on_hold,
-                        $.todo_item_cancelled,
-                        $.todo_item_urgent,
-                        $.todo_item_uncertain,
-                        $.todo_item_recurring,
-                    )
+                    $._any_todo_state,
                 ),
 
                 token(/\s+/),
@@ -1882,12 +1544,7 @@ module.exports = grammar({
                 ),
 
                 repeat(
-                    choice(
-                        $.todo_item3,
-                        $.todo_item4,
-                        $.todo_item5,
-                        $.todo_item6,
-                    ),
+                    $._any_list_item_level_3,
                 ),
             )
         ),
@@ -1899,17 +1556,7 @@ module.exports = grammar({
 
                 field(
                     "state",
-
-                    choice(
-                        $.todo_item_undone,
-                        $.todo_item_pending,
-                        $.todo_item_done,
-                        $.todo_item_on_hold,
-                        $.todo_item_cancelled,
-                        $.todo_item_urgent,
-                        $.todo_item_uncertain,
-                        $.todo_item_recurring,
-                    )
+                    $._any_todo_state,
                 ),
 
                 token(/\s+/),
@@ -1920,11 +1567,7 @@ module.exports = grammar({
                 ),
 
                 repeat(
-                    choice(
-                        $.todo_item4,
-                        $.todo_item5,
-                        $.todo_item6,
-                    ),
+                    $._any_list_item_level_4,
                 ),
             )
         ),
@@ -1936,17 +1579,7 @@ module.exports = grammar({
 
                 field(
                     "state",
-
-                    choice(
-                        $.todo_item_undone,
-                        $.todo_item_pending,
-                        $.todo_item_done,
-                        $.todo_item_on_hold,
-                        $.todo_item_cancelled,
-                        $.todo_item_urgent,
-                        $.todo_item_uncertain,
-                        $.todo_item_recurring,
-                    )
+                    $._any_todo_state,
                 ),
 
                 token(/\s+/),
@@ -1957,10 +1590,7 @@ module.exports = grammar({
                 ),
 
                 repeat(
-                    choice(
-                        $.todo_item5,
-                        $.todo_item6,
-                    )
+                    $._any_list_item_level_5,
                 ),
             )
         ),
@@ -1972,17 +1602,7 @@ module.exports = grammar({
 
                 field(
                     "state",
-
-                    choice(
-                        $.todo_item_undone,
-                        $.todo_item_pending,
-                        $.todo_item_done,
-                        $.todo_item_on_hold,
-                        $.todo_item_cancelled,
-                        $.todo_item_urgent,
-                        $.todo_item_uncertain,
-                        $.todo_item_recurring,
-                    )
+                    $._any_todo_state,
                 ),
 
                 token(/\s+/),
@@ -1993,7 +1613,7 @@ module.exports = grammar({
                 ),
 
                 repeat(
-                    $.todo_item6,
+                    $._any_list_item_level_6,
                 ),
             )
         ),
@@ -2005,17 +1625,7 @@ module.exports = grammar({
 
                 field(
                     "state",
-
-                    choice(
-                        $.todo_item_undone,
-                        $.todo_item_pending,
-                        $.todo_item_done,
-                        $.todo_item_on_hold,
-                        $.todo_item_cancelled,
-                        $.todo_item_urgent,
-                        $.todo_item_uncertain,
-                        $.todo_item_recurring,
-                    )
+                    $._any_todo_state,
                 ),
 
                 token(/\s+/),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1525,89 +1525,8 @@
           {
             "type": "REPEAT",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link2"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link2"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list2"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list2"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list6"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_any_list_item_level_2"
             }
           }
         ]
@@ -1668,73 +1587,8 @@
           {
             "type": "REPEAT",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list6"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_any_list_item_level_3"
             }
           }
         ]
@@ -1795,57 +1649,8 @@
           {
             "type": "REPEAT",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list6"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_any_list_item_level_4"
             }
           }
         ]
@@ -1906,41 +1711,8 @@
           {
             "type": "REPEAT",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list6"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_any_list_item_level_5"
             }
           }
         ]
@@ -2001,25 +1773,8 @@
           {
             "type": "REPEAT",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list6"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_any_list_item_level_6"
             }
           }
         ]
@@ -2135,89 +1890,8 @@
           {
             "type": "REPEAT",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link2"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link2"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list2"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list2"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list6"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_any_list_item_level_2"
             }
           }
         ]
@@ -2278,73 +1952,8 @@
           {
             "type": "REPEAT",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list6"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_any_list_item_level_3"
             }
           }
         ]
@@ -2405,57 +2014,8 @@
           {
             "type": "REPEAT",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list6"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_any_list_item_level_4"
             }
           }
         ]
@@ -2516,41 +2076,8 @@
           {
             "type": "REPEAT",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list6"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_any_list_item_level_5"
             }
           }
         ]
@@ -2611,25 +2138,8 @@
           {
             "type": "REPEAT",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list6"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_any_list_item_level_6"
             }
           }
         ]
@@ -3616,135 +3126,184 @@
         ]
       }
     },
+    "_any_list_item_level_1": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "unordered_list1"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ordered_list1"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "todo_item1"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "unordered_link1"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ordered_link1"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_any_list_item_level_2"
+        }
+      ]
+    },
+    "_any_list_item_level_2": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "unordered_list2"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ordered_list2"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "todo_item2"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "unordered_link2"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ordered_link2"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_any_list_item_level_3"
+        }
+      ]
+    },
+    "_any_list_item_level_3": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "unordered_list3"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ordered_list3"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "todo_item3"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "unordered_link3"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ordered_link3"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_any_list_item_level_4"
+        }
+      ]
+    },
+    "_any_list_item_level_4": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "unordered_list4"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ordered_list4"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "todo_item4"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "unordered_link4"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ordered_link4"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_any_list_item_level_5"
+        }
+      ]
+    },
+    "_any_list_item_level_5": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "unordered_list5"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ordered_list5"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "todo_item5"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "unordered_link5"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ordered_link5"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_any_list_item_level_6"
+        }
+      ]
+    },
+    "_any_list_item_level_6": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "unordered_list6"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ordered_list6"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "todo_item6"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "unordered_link6"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ordered_link6"
+        }
+      ]
+    },
     "generic_list": {
       "type": "PREC_RIGHT",
       "value": 0,
       "content": {
         "type": "REPEAT1",
         "content": {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "unordered_list1"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "unordered_list2"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "unordered_list3"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "unordered_list4"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "unordered_list5"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "unordered_list6"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "ordered_list1"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "ordered_list2"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "ordered_list3"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "ordered_list4"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "ordered_list5"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "ordered_list6"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "todo_item1"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "todo_item2"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "todo_item3"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "todo_item4"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "todo_item5"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "todo_item6"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "unordered_link1"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "unordered_link2"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "unordered_link3"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "unordered_link4"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "unordered_link5"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "unordered_link6"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "ordered_link1"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "ordered_link2"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "ordered_link3"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "ordered_link4"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "ordered_link5"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "ordered_link6"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_any_list_item_level_1"
         }
       }
     },
@@ -3769,109 +3328,8 @@
           {
             "type": "REPEAT",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item2"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list2"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list2"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link2"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link2"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link6"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_any_list_item_level_2"
             }
           }
         ]
@@ -3898,89 +3356,8 @@
           {
             "type": "REPEAT",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link6"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_any_list_item_level_3"
             }
           }
         ]
@@ -4007,69 +3384,8 @@
           {
             "type": "REPEAT",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link6"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_any_list_item_level_4"
             }
           }
         ]
@@ -4096,49 +3412,8 @@
           {
             "type": "REPEAT",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link6"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_any_list_item_level_5"
             }
           }
         ]
@@ -4165,29 +3440,8 @@
           {
             "type": "REPEAT",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link6"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_any_list_item_level_6"
             }
           }
         ]
@@ -4235,109 +3489,8 @@
           {
             "type": "REPEAT",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item2"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list2"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list2"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link2"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link2"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link6"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_any_list_item_level_2"
             }
           }
         ]
@@ -4364,89 +3517,8 @@
           {
             "type": "REPEAT",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link6"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_any_list_item_level_3"
             }
           }
         ]
@@ -4473,69 +3545,8 @@
           {
             "type": "REPEAT",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link6"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_any_list_item_level_4"
             }
           }
         ]
@@ -4562,49 +3573,8 @@
           {
             "type": "REPEAT",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link6"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_any_list_item_level_5"
             }
           }
         ]
@@ -4631,29 +3601,8 @@
           {
             "type": "REPEAT",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_list6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_list6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "unordered_link6"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "ordered_link6"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_any_list_item_level_6"
             }
           }
         ]
@@ -4760,6 +3709,43 @@
         ]
       }
     },
+    "_any_todo_state": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "todo_item_undone"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "todo_item_pending"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "todo_item_done"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "todo_item_on_hold"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "todo_item_cancelled"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "todo_item_urgent"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "todo_item_uncertain"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "todo_item_recurring"
+        }
+      ]
+    },
     "todo_item1": {
       "type": "PREC_RIGHT",
       "value": 0,
@@ -4774,41 +3760,8 @@
             "type": "FIELD",
             "name": "state",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_undone"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_pending"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_done"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_on_hold"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_cancelled"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_urgent"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_uncertain"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_recurring"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_any_todo_state"
             }
           },
           {
@@ -4829,29 +3782,8 @@
           {
             "type": "REPEAT",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item2"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item6"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_any_list_item_level_2"
             }
           }
         ]
@@ -4871,41 +3803,8 @@
             "type": "FIELD",
             "name": "state",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_undone"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_pending"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_done"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_on_hold"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_cancelled"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_urgent"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_uncertain"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_recurring"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_any_todo_state"
             }
           },
           {
@@ -4926,25 +3825,8 @@
           {
             "type": "REPEAT",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item6"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_any_list_item_level_3"
             }
           }
         ]
@@ -4964,41 +3846,8 @@
             "type": "FIELD",
             "name": "state",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_undone"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_pending"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_done"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_on_hold"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_cancelled"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_urgent"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_uncertain"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_recurring"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_any_todo_state"
             }
           },
           {
@@ -5019,21 +3868,8 @@
           {
             "type": "REPEAT",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item6"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_any_list_item_level_4"
             }
           }
         ]
@@ -5053,41 +3889,8 @@
             "type": "FIELD",
             "name": "state",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_undone"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_pending"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_done"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_on_hold"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_cancelled"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_urgent"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_uncertain"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_recurring"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_any_todo_state"
             }
           },
           {
@@ -5108,17 +3911,8 @@
           {
             "type": "REPEAT",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item6"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_any_list_item_level_5"
             }
           }
         ]
@@ -5138,41 +3932,8 @@
             "type": "FIELD",
             "name": "state",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_undone"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_pending"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_done"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_on_hold"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_cancelled"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_urgent"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_uncertain"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_recurring"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_any_todo_state"
             }
           },
           {
@@ -5194,7 +3955,7 @@
             "type": "REPEAT",
             "content": {
               "type": "SYMBOL",
-              "name": "todo_item6"
+              "name": "_any_list_item_level_6"
             }
           }
         ]
@@ -5214,41 +3975,8 @@
             "type": "FIELD",
             "name": "state",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_undone"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_pending"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_done"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_on_hold"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_cancelled"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_urgent"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_uncertain"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "todo_item_recurring"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_any_todo_state"
             }
           },
           {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1403,6 +1403,26 @@
           "named": true
         },
         {
+          "type": "todo_item2",
+          "named": true
+        },
+        {
+          "type": "todo_item3",
+          "named": true
+        },
+        {
+          "type": "todo_item4",
+          "named": true
+        },
+        {
+          "type": "todo_item5",
+          "named": true
+        },
+        {
+          "type": "todo_item6",
+          "named": true
+        },
+        {
           "type": "unordered_link2",
           "named": true
         },
@@ -1515,6 +1535,22 @@
           "named": true
         },
         {
+          "type": "todo_item3",
+          "named": true
+        },
+        {
+          "type": "todo_item4",
+          "named": true
+        },
+        {
+          "type": "todo_item5",
+          "named": true
+        },
+        {
+          "type": "todo_item6",
+          "named": true
+        },
+        {
           "type": "unordered_link3",
           "named": true
         },
@@ -1611,6 +1647,18 @@
           "named": true
         },
         {
+          "type": "todo_item4",
+          "named": true
+        },
+        {
+          "type": "todo_item5",
+          "named": true
+        },
+        {
+          "type": "todo_item6",
+          "named": true
+        },
+        {
           "type": "unordered_link4",
           "named": true
         },
@@ -1691,6 +1739,14 @@
           "named": true
         },
         {
+          "type": "todo_item5",
+          "named": true
+        },
+        {
+          "type": "todo_item6",
+          "named": true
+        },
+        {
           "type": "unordered_link5",
           "named": true
         },
@@ -1752,6 +1808,10 @@
         },
         {
           "type": "ordered_list6",
+          "named": true
+        },
+        {
+          "type": "todo_item6",
           "named": true
         },
         {
@@ -2929,6 +2989,46 @@
       "required": true,
       "types": [
         {
+          "type": "ordered_link2",
+          "named": true
+        },
+        {
+          "type": "ordered_link3",
+          "named": true
+        },
+        {
+          "type": "ordered_link4",
+          "named": true
+        },
+        {
+          "type": "ordered_link5",
+          "named": true
+        },
+        {
+          "type": "ordered_link6",
+          "named": true
+        },
+        {
+          "type": "ordered_list2",
+          "named": true
+        },
+        {
+          "type": "ordered_list3",
+          "named": true
+        },
+        {
+          "type": "ordered_list4",
+          "named": true
+        },
+        {
+          "type": "ordered_list5",
+          "named": true
+        },
+        {
+          "type": "ordered_list6",
+          "named": true
+        },
+        {
           "type": "todo_item2",
           "named": true
         },
@@ -2949,7 +3049,47 @@
           "named": true
         },
         {
+          "type": "unordered_link2",
+          "named": true
+        },
+        {
+          "type": "unordered_link3",
+          "named": true
+        },
+        {
+          "type": "unordered_link4",
+          "named": true
+        },
+        {
+          "type": "unordered_link5",
+          "named": true
+        },
+        {
+          "type": "unordered_link6",
+          "named": true
+        },
+        {
           "type": "unordered_list1_prefix",
+          "named": true
+        },
+        {
+          "type": "unordered_list2",
+          "named": true
+        },
+        {
+          "type": "unordered_list3",
+          "named": true
+        },
+        {
+          "type": "unordered_list4",
+          "named": true
+        },
+        {
+          "type": "unordered_list5",
+          "named": true
+        },
+        {
+          "type": "unordered_list6",
           "named": true
         }
       ]
@@ -3013,6 +3153,38 @@
       "required": true,
       "types": [
         {
+          "type": "ordered_link3",
+          "named": true
+        },
+        {
+          "type": "ordered_link4",
+          "named": true
+        },
+        {
+          "type": "ordered_link5",
+          "named": true
+        },
+        {
+          "type": "ordered_link6",
+          "named": true
+        },
+        {
+          "type": "ordered_list3",
+          "named": true
+        },
+        {
+          "type": "ordered_list4",
+          "named": true
+        },
+        {
+          "type": "ordered_list5",
+          "named": true
+        },
+        {
+          "type": "ordered_list6",
+          "named": true
+        },
+        {
           "type": "todo_item3",
           "named": true
         },
@@ -3029,7 +3201,39 @@
           "named": true
         },
         {
+          "type": "unordered_link3",
+          "named": true
+        },
+        {
+          "type": "unordered_link4",
+          "named": true
+        },
+        {
+          "type": "unordered_link5",
+          "named": true
+        },
+        {
+          "type": "unordered_link6",
+          "named": true
+        },
+        {
           "type": "unordered_list2_prefix",
+          "named": true
+        },
+        {
+          "type": "unordered_list3",
+          "named": true
+        },
+        {
+          "type": "unordered_list4",
+          "named": true
+        },
+        {
+          "type": "unordered_list5",
+          "named": true
+        },
+        {
+          "type": "unordered_list6",
           "named": true
         }
       ]
@@ -3093,6 +3297,30 @@
       "required": true,
       "types": [
         {
+          "type": "ordered_link4",
+          "named": true
+        },
+        {
+          "type": "ordered_link5",
+          "named": true
+        },
+        {
+          "type": "ordered_link6",
+          "named": true
+        },
+        {
+          "type": "ordered_list4",
+          "named": true
+        },
+        {
+          "type": "ordered_list5",
+          "named": true
+        },
+        {
+          "type": "ordered_list6",
+          "named": true
+        },
+        {
           "type": "todo_item4",
           "named": true
         },
@@ -3105,7 +3333,31 @@
           "named": true
         },
         {
+          "type": "unordered_link4",
+          "named": true
+        },
+        {
+          "type": "unordered_link5",
+          "named": true
+        },
+        {
+          "type": "unordered_link6",
+          "named": true
+        },
+        {
           "type": "unordered_list3_prefix",
+          "named": true
+        },
+        {
+          "type": "unordered_list4",
+          "named": true
+        },
+        {
+          "type": "unordered_list5",
+          "named": true
+        },
+        {
+          "type": "unordered_list6",
           "named": true
         }
       ]
@@ -3169,6 +3421,22 @@
       "required": true,
       "types": [
         {
+          "type": "ordered_link5",
+          "named": true
+        },
+        {
+          "type": "ordered_link6",
+          "named": true
+        },
+        {
+          "type": "ordered_list5",
+          "named": true
+        },
+        {
+          "type": "ordered_list6",
+          "named": true
+        },
+        {
           "type": "todo_item5",
           "named": true
         },
@@ -3177,7 +3445,23 @@
           "named": true
         },
         {
+          "type": "unordered_link5",
+          "named": true
+        },
+        {
+          "type": "unordered_link6",
+          "named": true
+        },
+        {
           "type": "unordered_list4_prefix",
+          "named": true
+        },
+        {
+          "type": "unordered_list5",
+          "named": true
+        },
+        {
+          "type": "unordered_list6",
           "named": true
         }
       ]
@@ -3241,11 +3525,27 @@
       "required": true,
       "types": [
         {
+          "type": "ordered_link6",
+          "named": true
+        },
+        {
+          "type": "ordered_list6",
+          "named": true
+        },
+        {
           "type": "todo_item6",
           "named": true
         },
         {
+          "type": "unordered_link6",
+          "named": true
+        },
+        {
           "type": "unordered_list5_prefix",
+          "named": true
+        },
+        {
+          "type": "unordered_list6",
           "named": true
         }
       ]
@@ -3424,6 +3724,26 @@
           "named": true
         },
         {
+          "type": "todo_item2",
+          "named": true
+        },
+        {
+          "type": "todo_item3",
+          "named": true
+        },
+        {
+          "type": "todo_item4",
+          "named": true
+        },
+        {
+          "type": "todo_item5",
+          "named": true
+        },
+        {
+          "type": "todo_item6",
+          "named": true
+        },
+        {
           "type": "unordered_link1_prefix",
           "named": true
         },
@@ -3536,6 +3856,22 @@
           "named": true
         },
         {
+          "type": "todo_item3",
+          "named": true
+        },
+        {
+          "type": "todo_item4",
+          "named": true
+        },
+        {
+          "type": "todo_item5",
+          "named": true
+        },
+        {
+          "type": "todo_item6",
+          "named": true
+        },
+        {
           "type": "unordered_link2_prefix",
           "named": true
         },
@@ -3632,6 +3968,18 @@
           "named": true
         },
         {
+          "type": "todo_item4",
+          "named": true
+        },
+        {
+          "type": "todo_item5",
+          "named": true
+        },
+        {
+          "type": "todo_item6",
+          "named": true
+        },
+        {
           "type": "unordered_link3_prefix",
           "named": true
         },
@@ -3712,6 +4060,14 @@
           "named": true
         },
         {
+          "type": "todo_item5",
+          "named": true
+        },
+        {
+          "type": "todo_item6",
+          "named": true
+        },
+        {
           "type": "unordered_link4_prefix",
           "named": true
         },
@@ -3773,6 +4129,10 @@
         },
         {
           "type": "ordered_list6",
+          "named": true
+        },
+        {
+          "type": "todo_item6",
           "named": true
         },
         {


### PR DESCRIPTION
Prior to this PR, the following is invalid syntax:
```norg
- [ ] todo
-- nested list item
```

I do not see a good reason for this so I propose in this PR to truely support generic lists (i.e. allow nesting of any list item kind ((un)ordered list, link or todo) of lower levels into higher levels). To improve maintainability of the grammar I gathered these choices into simple objects. (Note, that higher level items contain lower level items directly in `_any_list_item_level_X` for all values smaller the current X).