### PR TITLE
[WIP] Multi-word tag parameter proposal

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1672,18 +1672,20 @@ module.exports = grammar({
                 ),
 
                 choice(
-                    seq(
-                        token.immediate(
-                            /[\t\v ]+/
-                        ),
-                        field(
-                            "parameters",
-                            $.paragraph_segment
-                        )
+                    token.immediate(
+                        /[\t\v ]*\n/,
                     ),
 
-                    token.immediate(
-                        /[\t\v ]*\n/
+                    seq(
+                        token.immediate(
+                            /[\t\v ]+/,
+                        ),
+
+                        $.parameters,
+
+                        token.immediate(
+                            '\n'
+                        ),
                     ),
                 ),
             )
@@ -1847,7 +1849,7 @@ module.exports = grammar({
                             /[\t\v ]+/,
                         ),
 
-                        $.tag_parameters,
+                        $.parameters,
 
                         token.immediate(
                             '\n'
@@ -1915,7 +1917,7 @@ module.exports = grammar({
                         /[\t\v ]+/,
                     ),
 
-                    $.tag_parameters,
+                    $.parameters,
 
                     token.immediate(
                         '\n'
@@ -1952,26 +1954,39 @@ module.exports = grammar({
             )
         ),
 
-        tag_param: $ => /\S+/,
-
-        tag_parameters: $ =>
-        seq(
-            field(
-                "parameter",
-                $.tag_param,
+        parameter: $ =>
+        prec.right(
+            repeat1(
+                /\S+/,
             ),
+        ),
 
-            repeat(
-                seq(
-                    token.immediate(/[\t\v ]+/),
+        _parameter_separator: $ => '|',
 
-                    field(
-                        "parameter",
-                        optional(
-                            $.tag_param,
+        parameters: $ =>
+        prec.left(
+            seq(
+                optional(
+                    $._parameter_separator,
+                ),
+                field(
+                    "parameter",
+                    $.parameter,
+                ),
+
+                repeat(
+                    seq(
+                        $._parameter_separator,
+
+                        field(
+                            "parameter",
+                            $.parameter,
                         ),
                     ),
-                )
+                ),
+                optional(
+                    $._parameter_separator,
+                ),
             ),
         ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4074,6 +4074,13 @@
             "type": "CHOICE",
             "members": [
               {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "[\\t\\v ]*\\n"
+                }
+              },
+              {
                 "type": "SEQ",
                 "members": [
                   {
@@ -4084,21 +4091,17 @@
                     }
                   },
                   {
-                    "type": "FIELD",
-                    "name": "parameters",
+                    "type": "SYMBOL",
+                    "name": "parameters"
+                  },
+                  {
+                    "type": "IMMEDIATE_TOKEN",
                     "content": {
-                      "type": "SYMBOL",
-                      "name": "paragraph_segment"
+                      "type": "STRING",
+                      "value": "\n"
                     }
                   }
                 ]
-              },
-              {
-                "type": "IMMEDIATE_TOKEN",
-                "content": {
-                  "type": "PATTERN",
-                  "value": "[\\t\\v ]*\\n"
-                }
               }
             ]
           }
@@ -4426,7 +4429,7 @@
                   },
                   {
                     "type": "SYMBOL",
-                    "name": "tag_parameters"
+                    "name": "parameters"
                   },
                   {
                     "type": "IMMEDIATE_TOKEN",
@@ -4573,7 +4576,7 @@
                 },
                 {
                   "type": "SYMBOL",
-                  "name": "tag_parameters"
+                  "name": "parameters"
                 },
                 {
                   "type": "IMMEDIATE_TOKEN",
@@ -4652,53 +4655,81 @@
         }
       ]
     },
-    "tag_param": {
-      "type": "PATTERN",
-      "value": "\\S+"
+    "parameter": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "REPEAT1",
+        "content": {
+          "type": "PATTERN",
+          "value": "\\S+"
+        }
+      }
     },
-    "tag_parameters": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "FIELD",
-          "name": "parameter",
-          "content": {
-            "type": "SYMBOL",
-            "name": "tag_param"
-          }
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "SEQ",
+    "_parameter_separator": {
+      "type": "STRING",
+      "value": "|"
+    },
+    "parameters": {
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
             "members": [
               {
-                "type": "IMMEDIATE_TOKEN",
-                "content": {
-                  "type": "PATTERN",
-                  "value": "[\\t\\v ]+"
-                }
+                "type": "SYMBOL",
+                "name": "_parameter_separator"
               },
               {
-                "type": "FIELD",
-                "name": "parameter",
-                "content": {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "tag_param"
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "FIELD",
+            "name": "parameter",
+            "content": {
+              "type": "SYMBOL",
+              "name": "parameter"
+            }
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_parameter_separator"
+                },
+                {
+                  "type": "FIELD",
+                  "name": "parameter",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "parameter"
+                  }
                 }
+              ]
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_parameter_separator"
+              },
+              {
+                "type": "BLANK"
               }
             ]
           }
-        }
-      ]
+        ]
+      }
     },
     "tag": {
       "type": "CHOICE",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -273,7 +273,7 @@
       "required": false,
       "types": [
         {
-          "type": "tag_parameters",
+          "type": "parameters",
           "named": true
         }
       ]
@@ -980,24 +980,18 @@
             "named": true
           }
         ]
-      },
-      "parameters": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "paragraph_segment",
-            "named": true
-          }
-        ]
       }
     },
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": true,
       "types": [
         {
           "type": "insertion_prefix",
+          "named": true
+        },
+        {
+          "type": "parameters",
           "named": true
         }
       ]
@@ -2372,6 +2366,27 @@
     }
   },
   {
+    "type": "parameter",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "parameters",
+    "named": true,
+    "fields": {
+      "parameter": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "parameter",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "quote",
     "named": true,
     "fields": {},
@@ -2652,11 +2667,11 @@
       "required": false,
       "types": [
         {
-          "type": "ranged_tag_end",
+          "type": "parameters",
           "named": true
         },
         {
-          "type": "tag_parameters",
+          "type": "ranged_tag_end",
           "named": true
         }
       ]
@@ -2914,22 +2929,6 @@
     "type": "tag_name_element",
     "named": true,
     "fields": {}
-  },
-  {
-    "type": "tag_parameters",
-    "named": true,
-    "fields": {
-      "parameter": {
-        "multiple": true,
-        "required": true,
-        "types": [
-          {
-            "type": "tag_param",
-            "named": true
-          }
-        ]
-      }
-    }
   },
   {
     "type": "todo_item1",
@@ -4918,10 +4917,6 @@
   },
   {
     "type": "strong_paragraph_delimiter",
-    "named": true
-  },
-  {
-    "type": "tag_param",
     "named": true
   },
   {

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -277,7 +277,7 @@ class Scanner
                 }
 
                 // This is a fallback. If the tag ends up not being `@end`
-                // then ignore the char if we are already inside of a ranged tag. 
+                // then ignore the char if we are already inside of a ranged tag.
                 if (m_TagLevel)
                 {
                     lexer->result_symbol = m_LastToken = WORD;
@@ -847,7 +847,7 @@ class Scanner
     {
         if (m_TagLevel)
         {
-            while (lexer->lookahead && lexer->lookahead != '\n')
+            while (lexer->lookahead && lexer->lookahead != '|' && lexer->lookahead != '\n')
                 advance(lexer);
 
             lexer->result_symbol = m_LastToken = WORD;

--- a/test/corpus/insertions.txt
+++ b/test/corpus/insertions.txt
@@ -26,12 +26,37 @@ The above renders a table of contents with a custom title.
     (insertion
         (insertion_prefix)
         (capitalized_word)
-        (paragraph_segment)
+        (parameters
+            (parameter)
+        )
     )
     (paragraph
         (paragraph_segment)
     )
 )
+
+====================================
+Insertion with Multi-Word Parameters
+====================================
+= Insertion first | second argument | third
+
+The above is an insertion with three arguments
+---
+(document
+    (insertion
+        (insertion_prefix)
+        (capitalized_word)
+        (parameters
+            (parameter)
+            (parameter)
+            (parameter)
+        )
+    )
+    (paragraph
+        (paragraph_segment)
+    )
+)
+
 
 ===================
 Variable Definition
@@ -44,7 +69,9 @@ The above is a variable definition.
     (insertion
         (insertion_prefix)
         (lowercase_word)
-        (paragraph_segment)
+        (parameters
+            (parameter)
+        )
     )
     (paragraph
         (paragraph_segment)

--- a/test/corpus/tags.txt
+++ b/test/corpus/tags.txt
@@ -32,7 +32,35 @@ No longer part of the ranged tag.
         (tag_name
             (tag_name_element)
         )
-        (tag_parameters (tag_param))
+        (parameters
+            (parameter)
+        )
+        (ranged_tag_content)
+        (ranged_tag_end)
+    )
+    (paragraph
+        (paragraph_segment)
+    )
+)
+
+=====================================
+Ranged Tag with Multi-Word Parameters
+=====================================
+@tag first | second argument | third
+print("Hello world")
+@end
+No longer part of the ranged tag.
+---
+(document
+    (ranged_tag
+        (tag_name
+            (tag_name_element)
+        )
+        (parameters
+            (parameter)
+            (parameter)
+            (parameter)
+        )
         (ranged_tag_content)
         (ranged_tag_end)
     )
@@ -115,7 +143,9 @@ Lol
             (tag_name
                 (tag_name_element)
             )
-            (tag_parameters (tag_param))
+            (parameters
+                (parameter)
+            )
         )
         (quote
             (quote1
@@ -126,5 +156,29 @@ Lol
     )
     (paragraph
         (paragraph_segment)
+    )
+)
+
+========================================
+Carryover Tag with Multi-Word Parameters
+========================================
+#tag first | second argument | third
+Lol
+---
+(document
+    (carryover_tag_set
+        (carryover_tag
+            (tag_name
+                (tag_name_element)
+            )
+            (parameters
+                (parameter)
+                (parameter)
+                (parameter)
+            )
+        )
+        (paragraph
+            (paragraph_segment)
+        )
     )
 )


### PR DESCRIPTION
Adds the multi-word parameter support proposed here:
https://github.com/nvim-neorg/dev-notes/blob/main/syntax/multi-word-tag-parameters/index.norg

We will likely be adapting things slightly to use quotes for multi-word parameter delimiting instead of `|`.