### PR TITLE
Ranged elements

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Run fuzzer
         run: |
           cd out/results
-          ../norg_fuzzer -dict=../norg.dict -max_total_time=7200 -timeout=1 ./corpus
+          ../norg_fuzzer -dict=../norg.dict -max_total_time=7200 -timeout=2 ./corpus
 
       - name: Check corpuses
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Cargo.lock
 package-lock.json
 yarn.lock
 *.log
+src/*.o

--- a/grammar.js
+++ b/grammar.js
@@ -1251,6 +1251,41 @@ module.exports = grammar({
             )
         ),
 
+        _quote1: $ =>
+        choice(
+            $.quote1,
+            $._quote2,
+        ),
+
+        _quote2: $ =>
+        choice(
+            $.quote2,
+            $._quote3,
+        ),
+
+        _quote3: $ =>
+        choice(
+            $.quote3,
+            $._quote4,
+        ),
+
+        _quote4: $ =>
+        choice(
+            $.quote4,
+            $._quote5,
+        ),
+
+        _quote5: $ =>
+        choice(
+            $.quote5,
+            $._quote6,
+        ),
+
+        _quote6: $ =>
+        choice(
+            $.quote6,
+        ),
+
         quote1: $ =>
         prec.right(0,
             seq(
@@ -1258,19 +1293,14 @@ module.exports = grammar({
 
                 field(
                     "content",
-                    $.paragraph,
+                    choice(
+                        $.paragraph,
+                        $._indent_segment_level_1,
+                    ),
                 ),
 
-                optional(prec(1, $._line_break)),
-
                 repeat(
-                    choice(
-                        $.quote2,
-                        $.quote3,
-                        $.quote4,
-                        $.quote5,
-                        $.quote6,
-                    ),
+                    $._quote2,
                 )
             )
         ),
@@ -1282,18 +1312,14 @@ module.exports = grammar({
 
                 field(
                     "content",
-                    $.paragraph,
+                    choice(
+                        $.paragraph,
+                        $._indent_segment_level_2,
+                    ),
                 ),
 
-                optional(prec(1, $._line_break)),
-
                 repeat(
-                    choice(
-                        $.quote3,
-                        $.quote4,
-                        $.quote5,
-                        $.quote6,
-                    ),
+                    $._quote3,
                 )
             )
         ),
@@ -1305,17 +1331,14 @@ module.exports = grammar({
 
                 field(
                     "content",
-                    $.paragraph,
+                    choice(
+                        $.paragraph,
+                        $._indent_segment_level_3,
+                    ),
                 ),
 
-                optional(prec(1, $._line_break)),
-
                 repeat(
-                    choice(
-                        $.quote4,
-                        $.quote5,
-                        $.quote6,
-                    ),
+                    $._quote4,
                 )
             )
         ),
@@ -1327,16 +1350,14 @@ module.exports = grammar({
 
                 field(
                     "content",
-                    $.paragraph,
+                    choice(
+                        $.paragraph,
+                        $._indent_segment_level_4,
+                    ),
                 ),
 
-                optional(prec(1, $._line_break)),
-
                 repeat(
-                    choice(
-                        $.quote5,
-                        $.quote6,
-                    ),
+                    $._quote5,
                 )
             )
         ),
@@ -1348,13 +1369,14 @@ module.exports = grammar({
 
                 field(
                     "content",
-                    $.paragraph,
+                    choice(
+                        $.paragraph,
+                        $._indent_segment_level_5,
+                    ),
                 ),
 
-                optional(prec(1, $._line_break)),
-
                 repeat(
-                    $.quote6,
+                    $._quote6,
                 )
             )
         ),
@@ -1366,11 +1388,11 @@ module.exports = grammar({
 
                 field(
                     "content",
-                    $.paragraph,
+                    choice(
+                        $.paragraph,
+                        $._indent_segment_level_6,
+                    ),
                 ),
-
-                optional(prec(1, $._line_break)),
-
             )
         ),
 
@@ -1433,15 +1455,8 @@ module.exports = grammar({
             $.ordered_link6,
         ),
 
-        // TODO: complete docs
-        generic_list: $ =>
-        prec.right(0,
-            repeat1(
-                $._any_list_item_level_1,
-            )
-        ),
-
-        indent_segment: $ =>
+        // indent segment levels
+        _indent_segment_level_1: $ =>
         prec.right(
             seq(
                 $.indent_modifier,
@@ -1450,14 +1465,115 @@ module.exports = grammar({
                         $.paragraph,
                         $._paragraph_break,
                         $.tag,
-                        // this following tag makes things complicated because it means we will need six of these indent_segment node types...
                         $._any_list_item_level_2,
+                        $._quote2,
                     ),
                 ),
                 optional(
                     $.weak_paragraph_delimiter,
                 ),
             ),
+        ),
+
+        _indent_segment_level_2: $ =>
+        prec.right(
+            seq(
+                $.indent_modifier,
+                repeat1(
+                    choice(
+                        $.paragraph,
+                        $._paragraph_break,
+                        $.tag,
+                        $._any_list_item_level_3,
+                        $._quote3,
+                    ),
+                ),
+                optional(
+                    $.weak_paragraph_delimiter,
+                ),
+            ),
+        ),
+
+        _indent_segment_level_3: $ =>
+        prec.right(
+            seq(
+                $.indent_modifier,
+                repeat1(
+                    choice(
+                        $.paragraph,
+                        $._paragraph_break,
+                        $.tag,
+                        $._any_list_item_level_4,
+                        $._quote4,
+                    ),
+                ),
+                optional(
+                    $.weak_paragraph_delimiter,
+                ),
+            ),
+        ),
+
+        _indent_segment_level_4: $ =>
+        prec.right(
+            seq(
+                $.indent_modifier,
+                repeat1(
+                    choice(
+                        $.paragraph,
+                        $._paragraph_break,
+                        $.tag,
+                        $._any_list_item_level_5,
+                        $._quote5,
+                    ),
+                ),
+                optional(
+                    $.weak_paragraph_delimiter,
+                ),
+            ),
+        ),
+
+        _indent_segment_level_5: $ =>
+        prec.right(
+            seq(
+                $.indent_modifier,
+                repeat1(
+                    choice(
+                        $.paragraph,
+                        $._paragraph_break,
+                        $.tag,
+                        $._any_list_item_level_6,
+                        $._quote6,
+                    ),
+                ),
+                optional(
+                    $.weak_paragraph_delimiter,
+                ),
+            ),
+        ),
+
+        _indent_segment_level_6: $ =>
+        prec.right(
+            seq(
+                $.indent_modifier,
+                repeat1(
+                    choice(
+                        $.paragraph,
+                        $._paragraph_break,
+                        $.tag,
+                    ),
+                ),
+                optional(
+                    $.weak_paragraph_delimiter,
+                ),
+            ),
+        ),
+
+        // TODO: complete docs
+        generic_list: $ =>
+        prec.right(0,
+            repeat1(
+                $._any_list_item_level_1,
+            )
         ),
 
         unordered_list1: $ =>
@@ -1469,7 +1585,7 @@ module.exports = grammar({
                     "content",
                     choice(
                         $.paragraph,
-                        $.indent_segment,
+                        $._indent_segment_level_1,
                     ),
                 ),
 
@@ -1486,7 +1602,10 @@ module.exports = grammar({
 
                 field(
                     "content",
-                    $.paragraph,
+                    choice(
+                        $.paragraph,
+                        $._indent_segment_level_2,
+                    ),
                 ),
 
                 repeat(
@@ -1502,7 +1621,10 @@ module.exports = grammar({
 
                 field(
                     "content",
-                    $.paragraph,
+                    choice(
+                        $.paragraph,
+                        $._indent_segment_level_3,
+                    ),
                 ),
 
                 repeat(
@@ -1518,7 +1640,10 @@ module.exports = grammar({
 
                 field(
                     "content",
-                    $.paragraph,
+                    choice(
+                        $.paragraph,
+                        $._indent_segment_level_4,
+                    ),
                 ),
 
                 repeat(
@@ -1534,7 +1659,10 @@ module.exports = grammar({
 
                 field(
                     "content",
-                    $.paragraph,
+                    choice(
+                        $.paragraph,
+                        $._indent_segment_level_5,
+                    ),
                 ),
 
                 repeat(
@@ -1550,7 +1678,10 @@ module.exports = grammar({
 
                 field(
                     "content",
-                    $.paragraph,
+                    choice(
+                        $.paragraph,
+                        $._indent_segment_level_6,
+                    ),
                 ),
             )
         ),
@@ -1562,7 +1693,10 @@ module.exports = grammar({
 
                 field(
                     "content",
-                    $.paragraph,
+                    choice(
+                        $.paragraph,
+                        $._indent_segment_level_1,
+                    ),
                 ),
 
                 repeat(
@@ -1578,7 +1712,10 @@ module.exports = grammar({
 
                 field(
                     "content",
-                    $.paragraph,
+                    choice(
+                        $.paragraph,
+                        $._indent_segment_level_2,
+                    ),
                 ),
 
                 repeat(
@@ -1594,7 +1731,10 @@ module.exports = grammar({
 
                 field(
                     "content",
-                    $.paragraph,
+                    choice(
+                        $.paragraph,
+                        $._indent_segment_level_3,
+                    ),
                 ),
 
                 repeat(
@@ -1610,7 +1750,10 @@ module.exports = grammar({
 
                 field(
                     "content",
-                    $.paragraph,
+                    choice(
+                        $.paragraph,
+                        $._indent_segment_level_4,
+                    ),
                 ),
 
                 repeat(
@@ -1626,7 +1769,10 @@ module.exports = grammar({
 
                 field(
                     "content",
-                    $.paragraph,
+                    choice(
+                        $.paragraph,
+                        $._indent_segment_level_5,
+                    ),
                 ),
 
                 repeat(
@@ -1642,7 +1788,10 @@ module.exports = grammar({
 
                 field(
                     "content",
-                    $.paragraph,
+                    choice(
+                        $.paragraph,
+                        $._indent_segment_level_6,
+                    ),
                 ),
             )
         ),

--- a/grammar.js
+++ b/grammar.js
@@ -3,6 +3,7 @@ module.exports = grammar({
 
     supertypes: $ => [
         $.attached_modifier,
+        $.ranged_attached_modifier,
         $.heading,
         $.detached_modifier,
         $.footnote,
@@ -143,6 +144,7 @@ module.exports = grammar({
         $.multi_footnote_suffix,
 
         $.link_modifier,
+        $.ranged_modifier,
 
         $.bold_open,
         $.bold_close,
@@ -226,12 +228,16 @@ module.exports = grammar({
             ),
         ),
 
-        // A paragraph segment can contain any paragraph element.
+        // A paragraph segment can contain any paragraph element or a
+        // `ranged_attached_modifier`. Note, that this object can contain
+        // arbitrary whitespace resulting in what may look like multiple
+        // paragraphs being joined into one (inside the ranged markup).
         paragraph_segment: $ =>
         prec.right(0,
             repeat1(
                 choice(
                     $._paragraph_element,
+                    $.ranged_attached_modifier,
                     alias($._conflict_open, "_lowercase"),
                 ),
             )
@@ -240,10 +246,25 @@ module.exports = grammar({
         // The attached modifiers canNOT contain a `paragraph_segment` directly,
         // because they:
         //   - require a higher precedence of their internals
+        //   - canNOT contain a `ranged_attached_modifier` element
         _attached_modifier_content: $ =>
         prec.right(1,
             repeat1(
                 choice(
+                    $._paragraph_element,
+                    alias($._conflict_open, "_lowercase"),
+                ),
+            ),
+        ),
+
+        // A ranged attached modifier can contain arbitrary whitespace compared
+        // to a normal `attached_modifier`.
+        _ranged_attached_modifier_content: $ =>
+        prec.right(1,
+            repeat1(
+                choice(
+                    $._paragraph_break,
+                    $._line_break,
                     $._paragraph_element,
                     alias($._conflict_open, "_lowercase"),
                 ),
@@ -261,6 +282,17 @@ module.exports = grammar({
                 ),
             ),
         ),
+        _ranged_verbatim_attached_modifier_content: $ =>
+        prec.right(1,
+            repeat1(
+                choice(
+                    $._paragraph_break,
+                    $._line_break,
+                    $._verbatim_paragraph_element,
+                ),
+            ),
+        ),
+
         // A linked attached modifier simply wraps a normal `attached_modifier`.
         _linked_attached_modifier: $ =>
         prec.right(2, seq(
@@ -305,6 +337,7 @@ module.exports = grammar({
             alias($.escape_sequence_prefix, "_lowercase"),
             alias($.any_char, "_lowercase"),
             alias($.link_modifier, "_lowercase"),
+            alias($.ranged_modifier, "_lowercase"),
             alias($.bold_open, "_lowercase"),
             alias($.bold_close, "_lowercase"),
             alias($.italic_open, "_lowercase"),
@@ -442,6 +475,216 @@ module.exports = grammar({
                 alias($.variable_open, "_lowercase"),
             )
         ),
+
+        // ---- RANGED ATTACHED MODIFIERS ----
+        ranged_bold_open: $ =>
+        prec.left(2, seq(
+            alias($.ranged_modifier, "_ranged_modifier"),
+            alias($.bold_open, "_bold_open"),
+        )),
+
+        ranged_bold_close: $ =>
+        prec.left(2, seq(
+            alias($.bold_close, "_bold_close"),
+            alias($.ranged_modifier, "_ranged_modifier"),
+        )),
+
+        ranged_bold: $ =>
+        prec.left(seq(
+            alias($.ranged_bold_open, "_open"),
+            $._ranged_attached_modifier_content,
+            alias($.ranged_bold_close, "_close"),
+        )),
+
+        ranged_italic_open: $ =>
+        prec.left(2, seq(
+            alias($.ranged_modifier, "_ranged_modifier"),
+            alias($.italic_open, "_italic_open"),
+        )),
+
+        ranged_italic_close: $ =>
+        prec.left(2, seq(
+            alias($.italic_close, "_italic_close"),
+            alias($.ranged_modifier, "_ranged_modifier"),
+        )),
+
+        ranged_italic: $ =>
+        prec.left(seq(
+            alias($.ranged_italic_open, "_open"),
+            $._ranged_attached_modifier_content,
+            alias($.ranged_italic_close, "_close"),
+        )),
+
+        ranged_strikethrough_open: $ =>
+        prec.left(2, seq(
+            alias($.ranged_modifier, "_ranged_modifier"),
+            alias($.strikethrough_open, "_strikethrough_open"),
+        )),
+
+        ranged_strikethrough_close: $ =>
+        prec.left(2, seq(
+            alias($.strikethrough_close, "_strikethrough_close"),
+            alias($.ranged_modifier, "_ranged_modifier"),
+        )),
+
+        ranged_strikethrough: $ =>
+        prec.left(seq(
+            alias($.ranged_strikethrough_open, "_open"),
+            $._ranged_attached_modifier_content,
+            alias($.ranged_strikethrough_close, "_close"),
+        )),
+
+        ranged_underline_open: $ =>
+        prec.left(2, seq(
+            alias($.ranged_modifier, "_ranged_modifier"),
+            alias($.underline_open, "_underline_open"),
+        )),
+
+        ranged_underline_close: $ =>
+        prec.left(2, seq(
+            alias($.underline_close, "_underline_close"),
+            alias($.ranged_modifier, "_ranged_modifier"),
+        )),
+
+        ranged_underline: $ =>
+        prec.left(seq(
+            alias($.ranged_underline_open, "_open"),
+            $._ranged_attached_modifier_content,
+            alias($.ranged_underline_close, "_close"),
+        )),
+
+        ranged_spoiler_open: $ =>
+        prec.left(2, seq(
+            alias($.ranged_modifier, "_ranged_modifier"),
+            alias($.spoiler_open, "_spoiler_open"),
+        )),
+
+        ranged_spoiler_close: $ =>
+        prec.left(2, seq(
+            alias($.spoiler_close, "_spoiler_close"),
+            alias($.ranged_modifier, "_ranged_modifier"),
+        )),
+
+        ranged_spoiler: $ =>
+        prec.left(seq(
+            alias($.ranged_spoiler_open, "_open"),
+            $._ranged_attached_modifier_content,
+            alias($.ranged_spoiler_close, "_close"),
+        )),
+
+        ranged_superscript_open: $ =>
+        prec.left(2, seq(
+            alias($.ranged_modifier, "_ranged_modifier"),
+            alias($.superscript_open, "_superscript_open"),
+        )),
+
+        ranged_superscript_close: $ =>
+        prec.left(2, seq(
+            alias($.superscript_close, "_superscript_close"),
+            alias($.ranged_modifier, "_ranged_modifier"),
+        )),
+
+        ranged_superscript: $ =>
+        prec.left(seq(
+            alias($.ranged_superscript_open, "_open"),
+            $._ranged_attached_modifier_content,
+            alias($.ranged_superscript_close, "_close"),
+        )),
+
+        ranged_subscript_open: $ =>
+        prec.left(2, seq(
+            alias($.ranged_modifier, "_ranged_modifier"),
+            alias($.subscript_open, "_subscript_open"),
+        )),
+
+        ranged_subscript_close: $ =>
+        prec.left(2, seq(
+            alias($.subscript_close, "_subscript_close"),
+            alias($.ranged_modifier, "_ranged_modifier"),
+        )),
+
+        ranged_subscript: $ =>
+        prec.left(seq(
+            alias($.ranged_subscript_open, "_open"),
+            $._ranged_attached_modifier_content,
+            alias($.ranged_subscript_close, "_close"),
+        )),
+
+        ranged_verbatim_open: $ =>
+        prec.left(2, seq(
+            alias($.ranged_modifier, "_ranged_modifier"),
+            alias($.verbatim_open, "_verbatim_open"),
+        )),
+
+        ranged_verbatim_close: $ =>
+        prec.left(2, seq(
+            alias($.verbatim_close, "_verbatim_close"),
+            alias($.ranged_modifier, "_ranged_modifier"),
+        )),
+
+        ranged_verbatim: $ =>
+        prec.left(seq(
+            alias($.ranged_verbatim_open, "_open"),
+            $._ranged_verbatim_attached_modifier_content,
+            alias($.ranged_verbatim_close, "_close"),
+        )),
+
+        ranged_inline_comment_open: $ =>
+        prec.left(2, seq(
+            alias($.ranged_modifier, "_ranged_modifier"),
+            alias($.inline_comment_open, "_inline_comment_open"),
+        )),
+
+        ranged_inline_comment_close: $ =>
+        prec.left(2, seq(
+            alias($.inline_comment_close, "_inline_comment_close"),
+            alias($.ranged_modifier, "_ranged_modifier"),
+        )),
+
+        ranged_inline_comment: $ =>
+        prec.left(seq(
+            alias($.ranged_inline_comment_open, "_open"),
+            $._ranged_verbatim_attached_modifier_content,
+            alias($.ranged_inline_comment_close, "_close"),
+        )),
+
+        ranged_inline_math_open: $ =>
+        prec.left(2, seq(
+            alias($.ranged_modifier, "_ranged_modifier"),
+            alias($.inline_math_open, "_inline_math_open"),
+        )),
+
+        ranged_inline_math_close: $ =>
+        prec.left(2, seq(
+            alias($.inline_math_close, "_inline_math_close"),
+            alias($.ranged_modifier, "_ranged_modifier"),
+        )),
+
+        ranged_inline_math: $ =>
+        prec.left(seq(
+            alias($.ranged_inline_math_open, "_open"),
+            $._ranged_verbatim_attached_modifier_content,
+            alias($.ranged_inline_math_close, "_close"),
+        )),
+
+        ranged_variable_open: $ =>
+        prec.left(2, seq(
+            alias($.ranged_modifier, "_ranged_modifier"),
+            alias($.variable_open, "_variable_open"),
+        )),
+
+        ranged_variable_close: $ =>
+        prec.left(2, seq(
+            alias($.variable_close, "_variable_close"),
+            alias($.ranged_modifier, "_ranged_modifier"),
+        )),
+
+        ranged_variable: $ =>
+        prec.left(seq(
+            alias($.ranged_variable_open, "_open"),
+            $._ranged_verbatim_attached_modifier_content,
+            alias($.ranged_variable_close, "_close"),
+        )),
 
         // Well, any character
         any_char: _ =>
@@ -2027,6 +2270,21 @@ module.exports = grammar({
             $.inline_comment,
             $.inline_math,
             $.variable,
+        ),
+
+        ranged_attached_modifier: $ =>
+        choice(
+            $.ranged_bold,
+            $.ranged_italic,
+            $.ranged_strikethrough,
+            $.ranged_underline,
+            $.ranged_spoiler,
+            $.ranged_superscript,
+            $.ranged_subscript,
+            $.ranged_verbatim,
+            $.ranged_inline_comment,
+            $.ranged_inline_math,
+            $.ranged_variable,
         ),
     }
 });

--- a/grammar.js
+++ b/grammar.js
@@ -236,9 +236,13 @@ module.exports = grammar({
                     ),
                 ),
 
-                optional(
-                    $._paragraph_break,
-                ),
+                // TODO(mrossinek): I do not see the need for this. If we do
+                // need it, we need to extract it into _paragraph again because
+                // having it here would cause the ends of detached modifiers
+                // like quotes and lists to break.
+                // optional(
+                //     $._paragraph_break,
+                // ),
             ),
         ),
 
@@ -1248,7 +1252,7 @@ module.exports = grammar({
                     $.quote3,
                     $.quote4,
                     $.quote5,
-                    $.quote6
+                    $.quote6,
                 )
             )
         ),
@@ -1260,7 +1264,7 @@ module.exports = grammar({
 
                 field(
                     "content",
-                    $.paragraph_segment,
+                    $.paragraph,
                 ),
 
                 optional(prec(1, $._line_break)),
@@ -1284,7 +1288,7 @@ module.exports = grammar({
 
                 field(
                     "content",
-                    $.paragraph_segment,
+                    $.paragraph,
                 ),
 
                 optional(prec(1, $._line_break)),
@@ -1307,7 +1311,7 @@ module.exports = grammar({
 
                 field(
                     "content",
-                    $.paragraph_segment,
+                    $.paragraph,
                 ),
 
                 optional(prec(1, $._line_break)),
@@ -1329,7 +1333,7 @@ module.exports = grammar({
 
                 field(
                     "content",
-                    $.paragraph_segment,
+                    $.paragraph,
                 ),
 
                 optional(prec(1, $._line_break)),
@@ -1350,7 +1354,7 @@ module.exports = grammar({
 
                 field(
                     "content",
-                    $.paragraph_segment,
+                    $.paragraph,
                 ),
 
                 optional(prec(1, $._line_break)),
@@ -1368,7 +1372,7 @@ module.exports = grammar({
 
                 field(
                     "content",
-                    $.paragraph_segment,
+                    $.paragraph,
                 ),
 
                 optional(prec(1, $._line_break)),

--- a/grammar.js
+++ b/grammar.js
@@ -119,6 +119,8 @@ module.exports = grammar({
         $.ordered_link5_prefix,
         $.ordered_link6_prefix,
 
+        $.indent_modifier,
+
         $.strong_paragraph_delimiter,
         $.weak_paragraph_delimiter,
         $.horizontal_line,
@@ -1447,6 +1449,25 @@ module.exports = grammar({
             )
         ),
 
+        indent_segment: $ =>
+        prec.right(
+            seq(
+                $.indent_modifier,
+                repeat1(
+                    choice(
+                        $.paragraph,
+                        $._paragraph_break,
+                        $.tag,
+                        // this following tag makes things complicated because it means we will need six of these indent_segment node types...
+                        $._any_list_item_level_2,
+                    ),
+                ),
+                optional(
+                    $.weak_paragraph_delimiter,
+                ),
+            ),
+        ),
+
         unordered_list1: $ =>
         prec.right(0,
             seq(
@@ -1454,7 +1475,10 @@ module.exports = grammar({
 
                 field(
                     "content",
-                    $.paragraph,
+                    choice(
+                        $.paragraph,
+                        $.indent_segment,
+                    ),
                 ),
 
                 repeat(

--- a/grammar.js
+++ b/grammar.js
@@ -144,7 +144,6 @@ module.exports = grammar({
         $.multi_footnote_suffix,
 
         $.link_modifier,
-        $.ranged_modifier,
 
         $.bold_open,
         $.bold_close,
@@ -178,6 +177,9 @@ module.exports = grammar({
 
         $.variable_open,
         $.variable_close,
+
+        $.ranged_modifier_open,
+        $.ranged_modifier_close,
     ],
 
     rules: {
@@ -197,7 +199,6 @@ module.exports = grammar({
                         $.marker,
                     )
                 ),
-
                 $.paragraph,
             )
         ),
@@ -266,6 +267,7 @@ module.exports = grammar({
                     $._paragraph_break,
                     $._line_break,
                     $._paragraph_element,
+                    $.ranged_attached_modifier,
                     alias($._conflict_open, "_lowercase"),
                 ),
             ),
@@ -337,7 +339,8 @@ module.exports = grammar({
             alias($.escape_sequence_prefix, "_lowercase"),
             alias($.any_char, "_lowercase"),
             alias($.link_modifier, "_lowercase"),
-            alias($.ranged_modifier, "_lowercase"),
+            alias($.ranged_modifier_open, "_lowercase"),
+            alias($.ranged_modifier_close, "_lowercase"),
             alias($.bold_open, "_lowercase"),
             alias($.bold_close, "_lowercase"),
             alias($.italic_open, "_lowercase"),
@@ -477,214 +480,104 @@ module.exports = grammar({
         ),
 
         // ---- RANGED ATTACHED MODIFIERS ----
-        ranged_bold_open: $ =>
-        prec.left(2, seq(
-            alias($.ranged_modifier, "_ranged_modifier"),
-            alias($.bold_open, "_bold_open"),
-        )),
-
-        ranged_bold_close: $ =>
-        prec.left(2, seq(
-            alias($.bold_close, "_bold_close"),
-            alias($.ranged_modifier, "_ranged_modifier"),
-        )),
-
         ranged_bold: $ =>
-        prec.left(seq(
-            alias($.ranged_bold_open, "_open"),
+        seq(
+            alias($.ranged_modifier_open, "_open"),
+            alias($.bold_open, "_open"),
             $._ranged_attached_modifier_content,
-            alias($.ranged_bold_close, "_close"),
-        )),
-
-        ranged_italic_open: $ =>
-        prec.left(2, seq(
-            alias($.ranged_modifier, "_ranged_modifier"),
-            alias($.italic_open, "_italic_open"),
-        )),
-
-        ranged_italic_close: $ =>
-        prec.left(2, seq(
-            alias($.italic_close, "_italic_close"),
-            alias($.ranged_modifier, "_ranged_modifier"),
-        )),
+            alias($.bold_close, "_close"),
+            alias($.ranged_modifier_close, "_close"),
+        ),
 
         ranged_italic: $ =>
-        prec.left(seq(
-            alias($.ranged_italic_open, "_open"),
+        seq(
+            alias($.ranged_modifier_open, "_open"),
+            alias($.italic_open, "_open"),
             $._ranged_attached_modifier_content,
-            alias($.ranged_italic_close, "_close"),
-        )),
-
-        ranged_strikethrough_open: $ =>
-        prec.left(2, seq(
-            alias($.ranged_modifier, "_ranged_modifier"),
-            alias($.strikethrough_open, "_strikethrough_open"),
-        )),
-
-        ranged_strikethrough_close: $ =>
-        prec.left(2, seq(
-            alias($.strikethrough_close, "_strikethrough_close"),
-            alias($.ranged_modifier, "_ranged_modifier"),
-        )),
+            alias($.italic_close, "_close"),
+            alias($.ranged_modifier_close, "_close"),
+        ),
 
         ranged_strikethrough: $ =>
-        prec.left(seq(
-            alias($.ranged_strikethrough_open, "_open"),
+        seq(
+            alias($.ranged_modifier_open, "_open"),
+            alias($.strikethrough_open, "_open"),
             $._ranged_attached_modifier_content,
-            alias($.ranged_strikethrough_close, "_close"),
-        )),
-
-        ranged_underline_open: $ =>
-        prec.left(2, seq(
-            alias($.ranged_modifier, "_ranged_modifier"),
-            alias($.underline_open, "_underline_open"),
-        )),
-
-        ranged_underline_close: $ =>
-        prec.left(2, seq(
-            alias($.underline_close, "_underline_close"),
-            alias($.ranged_modifier, "_ranged_modifier"),
-        )),
+            alias($.strikethrough_close, "_close"),
+            alias($.ranged_modifier_close, "_close"),
+        ),
 
         ranged_underline: $ =>
-        prec.left(seq(
-            alias($.ranged_underline_open, "_open"),
+        seq(
+            alias($.ranged_modifier_open, "_open"),
+            alias($.underline_open, "_open"),
             $._ranged_attached_modifier_content,
-            alias($.ranged_underline_close, "_close"),
-        )),
-
-        ranged_spoiler_open: $ =>
-        prec.left(2, seq(
-            alias($.ranged_modifier, "_ranged_modifier"),
-            alias($.spoiler_open, "_spoiler_open"),
-        )),
-
-        ranged_spoiler_close: $ =>
-        prec.left(2, seq(
-            alias($.spoiler_close, "_spoiler_close"),
-            alias($.ranged_modifier, "_ranged_modifier"),
-        )),
+            alias($.underline_close, "_close"),
+            alias($.ranged_modifier_close, "_close"),
+        ),
 
         ranged_spoiler: $ =>
-        prec.left(seq(
-            alias($.ranged_spoiler_open, "_open"),
+        seq(
+            alias($.ranged_modifier_open, "_open"),
+            alias($.spoiler_open, "_open"),
             $._ranged_attached_modifier_content,
-            alias($.ranged_spoiler_close, "_close"),
-        )),
-
-        ranged_superscript_open: $ =>
-        prec.left(2, seq(
-            alias($.ranged_modifier, "_ranged_modifier"),
-            alias($.superscript_open, "_superscript_open"),
-        )),
-
-        ranged_superscript_close: $ =>
-        prec.left(2, seq(
-            alias($.superscript_close, "_superscript_close"),
-            alias($.ranged_modifier, "_ranged_modifier"),
-        )),
+            alias($.spoiler_close, "_close"),
+            alias($.ranged_modifier_close, "_close"),
+        ),
 
         ranged_superscript: $ =>
-        prec.left(seq(
-            alias($.ranged_superscript_open, "_open"),
+        seq(
+            alias($.ranged_modifier_open, "_open"),
+            alias($.superscript_open, "_open"),
             $._ranged_attached_modifier_content,
-            alias($.ranged_superscript_close, "_close"),
-        )),
-
-        ranged_subscript_open: $ =>
-        prec.left(2, seq(
-            alias($.ranged_modifier, "_ranged_modifier"),
-            alias($.subscript_open, "_subscript_open"),
-        )),
-
-        ranged_subscript_close: $ =>
-        prec.left(2, seq(
-            alias($.subscript_close, "_subscript_close"),
-            alias($.ranged_modifier, "_ranged_modifier"),
-        )),
+            alias($.superscript_close, "_close"),
+            alias($.ranged_modifier_close, "_close"),
+        ),
 
         ranged_subscript: $ =>
-        prec.left(seq(
-            alias($.ranged_subscript_open, "_open"),
+        seq(
+            alias($.ranged_modifier_open, "_open"),
+            alias($.subscript_open, "_open"),
             $._ranged_attached_modifier_content,
-            alias($.ranged_subscript_close, "_close"),
-        )),
-
-        ranged_verbatim_open: $ =>
-        prec.left(2, seq(
-            alias($.ranged_modifier, "_ranged_modifier"),
-            alias($.verbatim_open, "_verbatim_open"),
-        )),
-
-        ranged_verbatim_close: $ =>
-        prec.left(2, seq(
-            alias($.verbatim_close, "_verbatim_close"),
-            alias($.ranged_modifier, "_ranged_modifier"),
-        )),
+            alias($.subscript_close, "_close"),
+            alias($.ranged_modifier_close, "_close"),
+        ),
 
         ranged_verbatim: $ =>
-        prec.left(seq(
-            alias($.ranged_verbatim_open, "_open"),
+        seq(
+            alias($.ranged_modifier_open, "_open"),
+            alias($.verbatim_open, "_open"),
             $._ranged_verbatim_attached_modifier_content,
-            alias($.ranged_verbatim_close, "_close"),
-        )),
-
-        ranged_inline_comment_open: $ =>
-        prec.left(2, seq(
-            alias($.ranged_modifier, "_ranged_modifier"),
-            alias($.inline_comment_open, "_inline_comment_open"),
-        )),
-
-        ranged_inline_comment_close: $ =>
-        prec.left(2, seq(
-            alias($.inline_comment_close, "_inline_comment_close"),
-            alias($.ranged_modifier, "_ranged_modifier"),
-        )),
+            alias($.verbatim_close, "_close"),
+            alias($.ranged_modifier_close, "_close"),
+        ),
 
         ranged_inline_comment: $ =>
-        prec.left(seq(
-            alias($.ranged_inline_comment_open, "_open"),
+        seq(
+            alias($.ranged_modifier_open, "_open"),
+            alias($.inline_comment_open, "_open"),
             $._ranged_verbatim_attached_modifier_content,
-            alias($.ranged_inline_comment_close, "_close"),
-        )),
-
-        ranged_inline_math_open: $ =>
-        prec.left(2, seq(
-            alias($.ranged_modifier, "_ranged_modifier"),
-            alias($.inline_math_open, "_inline_math_open"),
-        )),
-
-        ranged_inline_math_close: $ =>
-        prec.left(2, seq(
-            alias($.inline_math_close, "_inline_math_close"),
-            alias($.ranged_modifier, "_ranged_modifier"),
-        )),
+            alias($.inline_comment_close, "_close"),
+            alias($.ranged_modifier_close, "_close"),
+        ),
 
         ranged_inline_math: $ =>
-        prec.left(seq(
-            alias($.ranged_inline_math_open, "_open"),
+        seq(
+            alias($.ranged_modifier_open, "_open"),
+            alias($.inline_math_open, "_open"),
             $._ranged_verbatim_attached_modifier_content,
-            alias($.ranged_inline_math_close, "_close"),
-        )),
-
-        ranged_variable_open: $ =>
-        prec.left(2, seq(
-            alias($.ranged_modifier, "_ranged_modifier"),
-            alias($.variable_open, "_variable_open"),
-        )),
-
-        ranged_variable_close: $ =>
-        prec.left(2, seq(
-            alias($.variable_close, "_variable_close"),
-            alias($.ranged_modifier, "_ranged_modifier"),
-        )),
+            alias($.inline_math_close, "_close"),
+            alias($.ranged_modifier_close, "_close"),
+        ),
 
         ranged_variable: $ =>
-        prec.left(seq(
-            alias($.ranged_variable_open, "_open"),
+        seq(
+            alias($.ranged_modifier_open, "_open"),
+            alias($.variable_open, "_open"),
             $._ranged_verbatim_attached_modifier_content,
-            alias($.ranged_variable_close, "_close"),
-        )),
+            alias($.variable_close, "_close"),
+            alias($.ranged_modifier_close, "_close"),
+        ),
 
         // Well, any character
         any_char: _ =>

--- a/grammar.js
+++ b/grammar.js
@@ -200,12 +200,68 @@ module.exports = grammar({
             )
         ),
 
+        // Any word
         word: $ =>
         choice(
             alias($.lowercase_word, "_lowercase"),
             alias($.capitalized_word, "_uppercase"),
         ),
 
+        // Any regular text. A paragraph is made up of `paragraph_segment`
+        // objects and line breaks. It may optionally be followed by a paragraph
+        // break (which are two consecutive line breaks).
+        paragraph: $ =>
+        prec.right(0,
+            seq(
+                repeat1(
+                    choice(
+                        $.paragraph_segment,
+                        $._line_break,
+                    ),
+                ),
+
+                optional(
+                    $._paragraph_break,
+                ),
+            ),
+        ),
+
+        // A paragraph segment can contain any paragraph element.
+        paragraph_segment: $ =>
+        prec.right(0,
+            repeat1(
+                choice(
+                    $._paragraph_element,
+                    alias($._conflict_open, "_lowercase"),
+                ),
+            )
+        ),
+
+        // The attached modifiers canNOT contain a `paragraph_segment` directly,
+        // because they:
+        //   - require a higher precedence of their internals
+        _attached_modifier_content: $ =>
+        prec.right(1,
+            repeat1(
+                choice(
+                    $._paragraph_element,
+                    alias($._conflict_open, "_lowercase"),
+                ),
+            ),
+        ),
+
+        // Same as the non-verbatim modifier contents but using verbatim
+        // elements instead. It cannot contain `_conflict_open` because all of
+        // them are aliased to become verbatim.
+        _verbatim_modifier_content: $ =>
+        prec.right(1,
+            repeat1(
+                choice(
+                    $._verbatim_paragraph_element,
+                ),
+            ),
+        ),
+        // A linked attached modifier simply wraps a normal `attached_modifier`.
         _linked_attached_modifier: $ =>
         prec.right(2, seq(
             optional($.link_modifier),
@@ -213,18 +269,8 @@ module.exports = grammar({
             optional($.link_modifier),
         )),
 
-        // Any regular text
-        _paragraph: $ =>
-        prec.right(0,
-            seq(
-                $.paragraph,
-
-                optional(
-                    $._paragraph_break,
-                )
-            )
-        ),
-
+        // Any of the following choices are valid IN-LINE elements. Any
+        // multitude of these are combined to form a `paragraph_segment`.
         _paragraph_element: $ =>
         choice(
             alias($.word, "_word"),
@@ -250,168 +296,133 @@ module.exports = grammar({
             alias($.variable_close, "_lowercase"),
         ),
 
-        _multi_paragraph_element: $ =>
-        repeat1(
-            choice(
-                $._line_break,
-                $._paragraph_element,
-                $._conflict_open,
-            ),
-        ),
-
-        _verbatim_segment: $ =>
-        prec.left(1,
-            seq(
-                repeat1(
-                    choice(
-                        $._line_break,
-                        alias($.word, "_word"),
-                        alias($.space, "_space"),
-                        alias($.trailing_modifier, "_lowercase"),
-                        alias($.escape_sequence_prefix, "_lowercase"),
-                        alias($.any_char, "_lowercase"),
-                        alias($.link_modifier, "_lowercase"),
-                        alias($.bold_open, "_lowercase"),
-                        alias($.bold_close, "_lowercase"),
-                        alias($.italic_open, "_lowercase"),
-                        alias($.italic_close, "_lowercase"),
-                        alias($.strikethrough_open, "_lowercase"),
-                        alias($.strikethrough_close, "_lowercase"),
-                        alias($.underline_open, "_lowercase"),
-                        alias($.underline_close, "_lowercase"),
-                        alias($.spoiler_open, "_lowercase"),
-                        alias($.spoiler_close, "_lowercase"),
-                        alias($.superscript_open, "_lowercase"),
-                        alias($.superscript_close, "_lowercase"),
-                        alias($.subscript_open, "_lowercase"),
-                        alias($.subscript_close, "_lowercase"),
-                        alias($.verbatim_open, "_lowercase"),
-                        alias($.verbatim_close, "_lowercase"),
-                        alias($.inline_comment_open, "_lowercase"),
-                        alias($.inline_comment_close, "_lowercase"),
-                        alias($.inline_math_open, "_lowercase"),
-                        alias($.inline_math_close, "_lowercase"),
-                        alias($.variable_open, "_lowercase"),
-                        alias($.variable_close, "_lowercase"),
-                        alias($.link_description_begin, "_lowercase"),
-                        alias($.link_description_end, "_lowercase"),
-                        alias($.link_location_begin, "_lowercase"),
-                        alias($.link_location_end, "_lowercase"),
-                        alias($.link_file_begin, "_lowercase"),
-                        alias($.link_file_end, "_lowercase"),
-                        alias($.link_file_text, "_lowercase"),
-                        alias($.link_target_url, "_lowercase"),
-                        alias($.link_target_generic, "_lowercase"),
-                        alias($.link_target_external_file, "_lowercase"),
-                        alias($.link_target_marker, "_lowercase"),
-                        alias($.link_target_definition, "_lowercase"),
-                        alias($.link_target_footnote, "_lowercase"),
-                        alias($.link_target_heading1, "_lowercase"),
-                        alias($.link_target_heading2, "_lowercase"),
-                        alias($.link_target_heading3, "_lowercase"),
-                        alias($.link_target_heading4, "_lowercase"),
-                        alias($.link_target_heading5, "_lowercase"),
-                        alias($.link_target_heading6, "_lowercase"),
-                    ),
-                ),
-            ),
-        ),
-
-        paragraph_segment: $ =>
-        prec.right(0,
-            repeat1(
-                choice(
-                    $._paragraph_element,
-                    alias($._conflict_open, "_lowercase"),
-                ),
-            )
-        ),
-
-        paragraph: $ =>
-        prec.right(0,
-            repeat1(
-                choice(
-                    $.paragraph_segment,
-                    $._line_break,
-                )
-            ),
+        // A verbatim paragraph element essentially ignores all IN-LINE markup.
+        _verbatim_paragraph_element: $ =>
+        choice(
+            alias($.word, "_word"),
+            alias($.space, "_space"),
+            alias($.trailing_modifier, "_lowercase"),
+            alias($.escape_sequence_prefix, "_lowercase"),
+            alias($.any_char, "_lowercase"),
+            alias($.link_modifier, "_lowercase"),
+            alias($.bold_open, "_lowercase"),
+            alias($.bold_close, "_lowercase"),
+            alias($.italic_open, "_lowercase"),
+            alias($.italic_close, "_lowercase"),
+            alias($.strikethrough_open, "_lowercase"),
+            alias($.strikethrough_close, "_lowercase"),
+            alias($.underline_open, "_lowercase"),
+            alias($.underline_close, "_lowercase"),
+            alias($.spoiler_open, "_lowercase"),
+            alias($.spoiler_close, "_lowercase"),
+            alias($.superscript_open, "_lowercase"),
+            alias($.superscript_close, "_lowercase"),
+            alias($.subscript_open, "_lowercase"),
+            alias($.subscript_close, "_lowercase"),
+            alias($.verbatim_open, "_lowercase"),
+            alias($.verbatim_close, "_lowercase"),
+            alias($.inline_comment_open, "_lowercase"),
+            alias($.inline_comment_close, "_lowercase"),
+            alias($.inline_math_open, "_lowercase"),
+            alias($.inline_math_close, "_lowercase"),
+            alias($.variable_open, "_lowercase"),
+            alias($.variable_close, "_lowercase"),
+            alias($.link_description_begin, "_lowercase"),
+            alias($.link_description_end, "_lowercase"),
+            alias($.link_location_begin, "_lowercase"),
+            alias($.link_location_end, "_lowercase"),
+            alias($.link_file_begin, "_lowercase"),
+            alias($.link_file_end, "_lowercase"),
+            alias($.link_file_text, "_lowercase"),
+            alias($.link_target_url, "_lowercase"),
+            alias($.link_target_generic, "_lowercase"),
+            alias($.link_target_external_file, "_lowercase"),
+            alias($.link_target_marker, "_lowercase"),
+            alias($.link_target_definition, "_lowercase"),
+            alias($.link_target_footnote, "_lowercase"),
+            alias($.link_target_heading1, "_lowercase"),
+            alias($.link_target_heading2, "_lowercase"),
+            alias($.link_target_heading3, "_lowercase"),
+            alias($.link_target_heading4, "_lowercase"),
+            alias($.link_target_heading5, "_lowercase"),
+            alias($.link_target_heading6, "_lowercase"),
         ),
 
         // ---- ATTACHED MODIFIERS ----
         bold: $ =>
         seq(
             alias($.bold_open, "_open"),
-            $._multi_paragraph_element,
+            $._attached_modifier_content,
             alias($.bold_close, "_close"),
         ),
 
         italic: $ =>
         seq(
             alias($.italic_open, "_open"),
-            $._multi_paragraph_element,
+            $._attached_modifier_content,
             alias($.italic_close, "_close"),
         ),
 
         strikethrough: $ =>
         seq(
             alias($.strikethrough_open, "_open"),
-            $._multi_paragraph_element,
+            $._attached_modifier_content,
             alias($.strikethrough_close, "_close"),
         ),
 
         underline: $ =>
         seq(
             alias($.underline_open, "_open"),
-            $._multi_paragraph_element,
+            $._attached_modifier_content,
             alias($.underline_close, "_close"),
         ),
 
         spoiler: $ =>
         seq(
             alias($.spoiler_open, "_open"),
-            $._multi_paragraph_element,
+            $._attached_modifier_content,
             alias($.spoiler_close, "_close"),
         ),
 
         verbatim: $ =>
         seq(
             alias($.verbatim_open, "_open"),
-            $._verbatim_segment,
+            $._verbatim_modifier_content,
             alias($.verbatim_close, "_close"),
         ),
 
         superscript: $ =>
         seq(
             alias($.superscript_open, "_open"),
-            $._multi_paragraph_element,
+            $._attached_modifier_content,
             alias($.superscript_close, "_close"),
         ),
 
         subscript: $ =>
         seq(
             alias($.subscript_open, "_open"),
-            $._multi_paragraph_element,
+            $._attached_modifier_content,
             alias($.subscript_close, "_close"),
         ),
 
         inline_comment: $ =>
         seq(
             alias($.inline_comment_open, "_open"),
-            $._verbatim_segment,
+            $._verbatim_modifier_content,
             alias($.inline_comment_close, "_close"),
         ),
 
         inline_math: $ =>
         seq(
             alias($.inline_math_open, "_open"),
-            $._verbatim_segment,
+            $._verbatim_modifier_content,
             alias($.inline_math_close, "_close"),
         ),
 
         variable: $ =>
         seq(
             alias($.variable_open, "_open"),
-            $._verbatim_segment,
+            $._verbatim_modifier_content,
             alias($.variable_close, "_close"),
         ),
 
@@ -509,7 +520,7 @@ module.exports = grammar({
                     $.link_target_url,
                 ),
             ),
-            field("text", alias($._verbatim_segment, $.paragraph_segment)),
+            field("text", alias($._verbatim_modifier_content, $.paragraph_segment)),
         ),
 
         link: $ =>
@@ -851,7 +862,7 @@ module.exports = grammar({
 
                     repeat(
                         choice(
-                            $._paragraph,
+                            $.paragraph,
 
                             $._paragraph_break,
                             $.detached_modifier,
@@ -897,7 +908,7 @@ module.exports = grammar({
 
                     repeat(
                         choice(
-                            $._paragraph,
+                            $.paragraph,
 
                             $._paragraph_break,
                             $.detached_modifier,
@@ -939,7 +950,7 @@ module.exports = grammar({
 
                     repeat(
                         choice(
-                            $._paragraph,
+                            $.paragraph,
 
                             $._paragraph_break,
                             $.detached_modifier,
@@ -980,7 +991,7 @@ module.exports = grammar({
 
                     repeat(
                         choice(
-                            $._paragraph,
+                            $.paragraph,
 
                             $._paragraph_break,
                             $.detached_modifier,
@@ -1020,7 +1031,7 @@ module.exports = grammar({
 
                     repeat(
                         choice(
-                            $._paragraph,
+                            $.paragraph,
 
                             $._paragraph_break,
                             $.detached_modifier,
@@ -1059,7 +1070,7 @@ module.exports = grammar({
 
                     repeat(
                         choice(
-                            $._paragraph,
+                            $.paragraph,
 
                             $._paragraph_break,
                             $.detached_modifier,
@@ -1483,7 +1494,7 @@ module.exports = grammar({
                     "subtext",
                     repeat(
                         choice(
-                            $._paragraph,
+                            $.paragraph,
                             $.strong_paragraph_delimiter,
                             $.horizontal_line,
                             $.heading,
@@ -1705,7 +1716,7 @@ module.exports = grammar({
                     "content",
                     repeat(
                         choice(
-                            $._paragraph,
+                            $.paragraph,
                             $._paragraph_break,
 
                             $.detached_modifier,
@@ -1755,7 +1766,7 @@ module.exports = grammar({
                     "content",
                     repeat(
                         choice(
-                            $._paragraph,
+                            $.paragraph,
                             $._paragraph_break,
 
                             $.detached_modifier,
@@ -1864,7 +1875,7 @@ module.exports = grammar({
                     "target",
 
                     choice(
-                        $._paragraph,
+                        $.paragraph,
                         repeat1(
                             choice(
                                 $.detached_modifier,
@@ -2009,10 +2020,10 @@ module.exports = grammar({
             $.italic,
             $.strikethrough,
             $.underline,
-            $.verbatim,
             $.spoiler,
             $.superscript,
             $.subscript,
+            $.verbatim,
             $.inline_comment,
             $.inline_math,
             $.variable,

--- a/grammar.js
+++ b/grammar.js
@@ -3,7 +3,6 @@ module.exports = grammar({
 
     supertypes: $ => [
         $.attached_modifier,
-        $.ranged_attached_modifier,
         $.heading,
         $.detached_modifier,
         $.footnote,
@@ -23,6 +22,21 @@ module.exports = grammar({
         [$.inline_comment, $._conflict_open],
         [$.inline_math, $._conflict_open],
         [$.variable, $._conflict_open],
+
+        [$._ranged_bold, $._conflict_open],
+        [$._ranged_italic, $._conflict_open],
+        [$._ranged_strikethrough, $._conflict_open],
+        [$._ranged_underline, $._conflict_open],
+        [$._ranged_spoiler, $._conflict_open],
+        [$._ranged_verbatim, $._conflict_open],
+        [$._ranged_superscript, $._conflict_open],
+        [$._ranged_subscript, $._conflict_open],
+        [$._ranged_inline_comment, $._conflict_open],
+        [$._ranged_inline_math, $._conflict_open],
+        [$._ranged_variable, $._conflict_open],
+
+        [$._attached_modifier_content, $._ranged_attached_modifier_content],
+        [$._verbatim_modifier_content, $._ranged_verbatim_modifier_content],
 
         [$.bold, $._paragraph_element],
         [$.italic, $._paragraph_element],
@@ -286,6 +300,7 @@ module.exports = grammar({
                     $._paragraph_break,
                     $._line_break,
                     $._paragraph_element,
+                    $._ranged_attached_modifier,
                     $.ranged_attached_modifier,
                     alias($._conflict_open, "_lowercase"),
                 ),
@@ -303,7 +318,7 @@ module.exports = grammar({
                 ),
             ),
         ),
-        _ranged_verbatim_attached_modifier_content: $ =>
+        _ranged_verbatim_modifier_content: $ =>
         prec.right(1,
             repeat1(
                 choice(
@@ -405,81 +420,81 @@ module.exports = grammar({
 
         // ---- ATTACHED MODIFIERS ----
         bold: $ =>
-        seq(
+        prec(1, seq(
             alias($.bold_open, "_open"),
             $._attached_modifier_content,
             alias($.bold_close, "_close"),
-        ),
+        )),
 
         italic: $ =>
-        seq(
+        prec(1, seq(
             alias($.italic_open, "_open"),
             $._attached_modifier_content,
             alias($.italic_close, "_close"),
-        ),
+        )),
 
         strikethrough: $ =>
-        seq(
+        prec(1, seq(
             alias($.strikethrough_open, "_open"),
             $._attached_modifier_content,
             alias($.strikethrough_close, "_close"),
-        ),
+        )),
 
         underline: $ =>
-        seq(
+        prec(1, seq(
             alias($.underline_open, "_open"),
             $._attached_modifier_content,
             alias($.underline_close, "_close"),
-        ),
+        )),
 
         spoiler: $ =>
-        seq(
+        prec(1, seq(
             alias($.spoiler_open, "_open"),
             $._attached_modifier_content,
             alias($.spoiler_close, "_close"),
-        ),
+        )),
 
         verbatim: $ =>
-        seq(
+        prec(1, seq(
             alias($.verbatim_open, "_open"),
             $._verbatim_modifier_content,
             alias($.verbatim_close, "_close"),
-        ),
+        )),
 
         superscript: $ =>
-        seq(
+        prec(1, seq(
             alias($.superscript_open, "_open"),
             $._attached_modifier_content,
             alias($.superscript_close, "_close"),
-        ),
+        )),
 
         subscript: $ =>
-        seq(
+        prec(1, seq(
             alias($.subscript_open, "_open"),
             $._attached_modifier_content,
             alias($.subscript_close, "_close"),
-        ),
+        )),
 
         inline_comment: $ =>
-        seq(
+        prec(1, seq(
             alias($.inline_comment_open, "_open"),
             $._verbatim_modifier_content,
             alias($.inline_comment_close, "_close"),
-        ),
+        )),
 
         inline_math: $ =>
-        seq(
+        prec(1, seq(
             alias($.inline_math_open, "_open"),
             $._verbatim_modifier_content,
             alias($.inline_math_close, "_close"),
-        ),
+        )),
 
         variable: $ =>
-        seq(
+        prec(1, seq(
             alias($.variable_open, "_open"),
             $._verbatim_modifier_content,
             alias($.variable_close, "_close"),
-        ),
+        )),
 
         _conflict_open: $ =>
         prec.dynamic(-1,
@@ -498,104 +513,81 @@ module.exports = grammar({
             )
         ),
 
-        // ---- RANGED ATTACHED MODIFIERS ----
-        ranged_bold: $ =>
+        _ranged_bold: $ =>
         seq(
-            alias($.ranged_modifier_open, "_open"),
             alias($.bold_open, "_open"),
             $._ranged_attached_modifier_content,
             alias($.bold_close, "_close"),
-            alias($.ranged_modifier_close, "_close"),
         ),
 
-        ranged_italic: $ =>
+        _ranged_italic: $ =>
         seq(
-            alias($.ranged_modifier_open, "_open"),
             alias($.italic_open, "_open"),
             $._ranged_attached_modifier_content,
             alias($.italic_close, "_close"),
-            alias($.ranged_modifier_close, "_close"),
         ),
 
-        ranged_strikethrough: $ =>
+        _ranged_strikethrough: $ =>
         seq(
-            alias($.ranged_modifier_open, "_open"),
             alias($.strikethrough_open, "_open"),
             $._ranged_attached_modifier_content,
             alias($.strikethrough_close, "_close"),
-            alias($.ranged_modifier_close, "_close"),
         ),
 
-        ranged_underline: $ =>
+        _ranged_underline: $ =>
         seq(
-            alias($.ranged_modifier_open, "_open"),
             alias($.underline_open, "_open"),
             $._ranged_attached_modifier_content,
             alias($.underline_close, "_close"),
-            alias($.ranged_modifier_close, "_close"),
         ),
 
-        ranged_spoiler: $ =>
+        _ranged_spoiler: $ =>
         seq(
-            alias($.ranged_modifier_open, "_open"),
             alias($.spoiler_open, "_open"),
             $._ranged_attached_modifier_content,
             alias($.spoiler_close, "_close"),
-            alias($.ranged_modifier_close, "_close"),
         ),
 
-        ranged_superscript: $ =>
+        _ranged_superscript: $ =>
         seq(
-            alias($.ranged_modifier_open, "_open"),
             alias($.superscript_open, "_open"),
             $._ranged_attached_modifier_content,
             alias($.superscript_close, "_close"),
-            alias($.ranged_modifier_close, "_close"),
         ),
 
-        ranged_subscript: $ =>
+        _ranged_subscript: $ =>
         seq(
-            alias($.ranged_modifier_open, "_open"),
             alias($.subscript_open, "_open"),
             $._ranged_attached_modifier_content,
             alias($.subscript_close, "_close"),
-            alias($.ranged_modifier_close, "_close"),
         ),
 
-        ranged_verbatim: $ =>
+        _ranged_verbatim: $ =>
         seq(
-            alias($.ranged_modifier_open, "_open"),
             alias($.verbatim_open, "_open"),
-            $._ranged_verbatim_attached_modifier_content,
+            $._ranged_verbatim_modifier_content,
             alias($.verbatim_close, "_close"),
-            alias($.ranged_modifier_close, "_close"),
         ),
 
-        ranged_inline_comment: $ =>
+        _ranged_inline_comment: $ =>
         seq(
-            alias($.ranged_modifier_open, "_open"),
             alias($.inline_comment_open, "_open"),
-            $._ranged_verbatim_attached_modifier_content,
+            $._ranged_verbatim_modifier_content,
             alias($.inline_comment_close, "_close"),
-            alias($.ranged_modifier_close, "_close"),
         ),
 
-        ranged_inline_math: $ =>
+        _ranged_inline_math: $ =>
         seq(
-            alias($.ranged_modifier_open, "_open"),
             alias($.inline_math_open, "_open"),
-            $._ranged_verbatim_attached_modifier_content,
+            $._ranged_verbatim_modifier_content,
             alias($.inline_math_close, "_close"),
-            alias($.ranged_modifier_close, "_close"),
         ),
 
-        ranged_variable: $ =>
+        _ranged_variable: $ =>
         seq(
-            alias($.ranged_modifier_open, "_open"),
             alias($.variable_open, "_open"),
-            $._ranged_verbatim_attached_modifier_content,
+            $._ranged_verbatim_modifier_content,
             alias($.variable_close, "_close"),
-            alias($.ranged_modifier_close, "_close"),
         ),
 
         // Well, any character
@@ -2206,19 +2198,26 @@ module.exports = grammar({
             $.variable,
         ),
 
-        ranged_attached_modifier: $ =>
+        _ranged_attached_modifier: $ =>
         choice(
-            $.ranged_bold,
-            $.ranged_italic,
-            $.ranged_strikethrough,
-            $.ranged_underline,
-            $.ranged_spoiler,
-            $.ranged_superscript,
-            $.ranged_subscript,
-            $.ranged_verbatim,
-            $.ranged_inline_comment,
-            $.ranged_inline_math,
-            $.ranged_variable,
+            alias($._ranged_bold, $.bold),
+            alias($._ranged_italic, $.italic),
+            alias($._ranged_strikethrough, $.strikethrough),
+            alias($._ranged_underline, $.underline),
+            alias($._ranged_spoiler, $.spoiler),
+            alias($._ranged_superscript, $.superscript),
+            alias($._ranged_subscript, $.subscript),
+            alias($._ranged_verbatim, $.verbatim),
+            alias($._ranged_inline_comment, $.inline_comment),
+            alias($._ranged_inline_math, $.inline_math),
+            alias($._ranged_variable, $.variable),
+        ),
+
+        ranged_attached_modifier: $ =>
+        seq(
+            alias($.ranged_modifier_open, "_open"),
+            $._ranged_attached_modifier,
+            alias($.ranged_modifier_close, "_close"),
         ),
     }
 });

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3268,6 +3268,80 @@
         }
       }
     },
+    "_quote1": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "quote1"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_quote2"
+        }
+      ]
+    },
+    "_quote2": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "quote2"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_quote3"
+        }
+      ]
+    },
+    "_quote3": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "quote3"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_quote4"
+        }
+      ]
+    },
+    "_quote4": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "quote4"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_quote5"
+        }
+      ]
+    },
+    "_quote5": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "quote5"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_quote6"
+        }
+      ]
+    },
+    "_quote6": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "quote6"
+        }
+      ]
+    },
     "quote1": {
       "type": "PREC_RIGHT",
       "value": 0,
@@ -3282,52 +3356,24 @@
             "type": "FIELD",
             "name": "content",
             "content": {
-              "type": "SYMBOL",
-              "name": "paragraph"
-            }
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "PREC",
-                "value": 1,
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_line_break"
-                }
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          },
-          {
-            "type": "REPEAT",
-            "content": {
               "type": "CHOICE",
               "members": [
                 {
                   "type": "SYMBOL",
-                  "name": "quote2"
+                  "name": "paragraph"
                 },
                 {
                   "type": "SYMBOL",
-                  "name": "quote3"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "quote4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "quote5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "quote6"
+                  "name": "_indent_segment_level_1"
                 }
               ]
+            }
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_quote2"
             }
           }
         ]
@@ -3347,48 +3393,24 @@
             "type": "FIELD",
             "name": "content",
             "content": {
-              "type": "SYMBOL",
-              "name": "paragraph"
-            }
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "PREC",
-                "value": 1,
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_line_break"
-                }
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          },
-          {
-            "type": "REPEAT",
-            "content": {
               "type": "CHOICE",
               "members": [
                 {
                   "type": "SYMBOL",
-                  "name": "quote3"
+                  "name": "paragraph"
                 },
                 {
                   "type": "SYMBOL",
-                  "name": "quote4"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "quote5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "quote6"
+                  "name": "_indent_segment_level_2"
                 }
               ]
+            }
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_quote3"
             }
           }
         ]
@@ -3408,44 +3430,24 @@
             "type": "FIELD",
             "name": "content",
             "content": {
-              "type": "SYMBOL",
-              "name": "paragraph"
-            }
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "PREC",
-                "value": 1,
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_line_break"
-                }
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          },
-          {
-            "type": "REPEAT",
-            "content": {
               "type": "CHOICE",
               "members": [
                 {
                   "type": "SYMBOL",
-                  "name": "quote4"
+                  "name": "paragraph"
                 },
                 {
                   "type": "SYMBOL",
-                  "name": "quote5"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "quote6"
+                  "name": "_indent_segment_level_3"
                 }
               ]
+            }
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_quote4"
             }
           }
         ]
@@ -3465,40 +3467,24 @@
             "type": "FIELD",
             "name": "content",
             "content": {
-              "type": "SYMBOL",
-              "name": "paragraph"
-            }
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "PREC",
-                "value": 1,
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_line_break"
-                }
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          },
-          {
-            "type": "REPEAT",
-            "content": {
               "type": "CHOICE",
               "members": [
                 {
                   "type": "SYMBOL",
-                  "name": "quote5"
+                  "name": "paragraph"
                 },
                 {
                   "type": "SYMBOL",
-                  "name": "quote6"
+                  "name": "_indent_segment_level_4"
                 }
               ]
+            }
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_quote5"
             }
           }
         ]
@@ -3518,31 +3504,24 @@
             "type": "FIELD",
             "name": "content",
             "content": {
-              "type": "SYMBOL",
-              "name": "paragraph"
-            }
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "PREC",
-                "value": 1,
-                "content": {
+              "type": "CHOICE",
+              "members": [
+                {
                   "type": "SYMBOL",
-                  "name": "_line_break"
+                  "name": "paragraph"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_indent_segment_level_5"
                 }
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
+              ]
+            }
           },
           {
             "type": "REPEAT",
             "content": {
               "type": "SYMBOL",
-              "name": "quote6"
+              "name": "_quote6"
             }
           }
         ]
@@ -3562,25 +3541,18 @@
             "type": "FIELD",
             "name": "content",
             "content": {
-              "type": "SYMBOL",
-              "name": "paragraph"
-            }
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "PREC",
-                "value": 1,
-                "content": {
+              "type": "CHOICE",
+              "members": [
+                {
                   "type": "SYMBOL",
-                  "name": "_line_break"
+                  "name": "paragraph"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_indent_segment_level_6"
                 }
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
+              ]
+            }
           }
         ]
       }
@@ -3755,18 +3727,7 @@
         }
       ]
     },
-    "generic_list": {
-      "type": "PREC_RIGHT",
-      "value": 0,
-      "content": {
-        "type": "REPEAT1",
-        "content": {
-          "type": "SYMBOL",
-          "name": "_any_list_item_level_1"
-        }
-      }
-    },
-    "indent_segment": {
+    "_indent_segment_level_1": {
       "type": "PREC_RIGHT",
       "value": 0,
       "content": {
@@ -3796,6 +3757,10 @@
                 {
                   "type": "SYMBOL",
                   "name": "_any_list_item_level_2"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_quote2"
                 }
               ]
             }
@@ -3813,6 +3778,274 @@
             ]
           }
         ]
+      }
+    },
+    "_indent_segment_level_2": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "indent_modifier"
+          },
+          {
+            "type": "REPEAT1",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "paragraph"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_paragraph_break"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "tag"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_any_list_item_level_3"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_quote3"
+                }
+              ]
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "weak_paragraph_delimiter"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_indent_segment_level_3": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "indent_modifier"
+          },
+          {
+            "type": "REPEAT1",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "paragraph"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_paragraph_break"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "tag"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_any_list_item_level_4"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_quote4"
+                }
+              ]
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "weak_paragraph_delimiter"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_indent_segment_level_4": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "indent_modifier"
+          },
+          {
+            "type": "REPEAT1",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "paragraph"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_paragraph_break"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "tag"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_any_list_item_level_5"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_quote5"
+                }
+              ]
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "weak_paragraph_delimiter"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_indent_segment_level_5": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "indent_modifier"
+          },
+          {
+            "type": "REPEAT1",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "paragraph"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_paragraph_break"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "tag"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_any_list_item_level_6"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_quote6"
+                }
+              ]
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "weak_paragraph_delimiter"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_indent_segment_level_6": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "indent_modifier"
+          },
+          {
+            "type": "REPEAT1",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "paragraph"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_paragraph_break"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "tag"
+                }
+              ]
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "weak_paragraph_delimiter"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "generic_list": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "REPEAT1",
+        "content": {
+          "type": "SYMBOL",
+          "name": "_any_list_item_level_1"
+        }
       }
     },
     "unordered_list1": {
@@ -3837,7 +4070,7 @@
                 },
                 {
                   "type": "SYMBOL",
-                  "name": "indent_segment"
+                  "name": "_indent_segment_level_1"
                 }
               ]
             }
@@ -3866,8 +4099,17 @@
             "type": "FIELD",
             "name": "content",
             "content": {
-              "type": "SYMBOL",
-              "name": "paragraph"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "paragraph"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_indent_segment_level_2"
+                }
+              ]
             }
           },
           {
@@ -3894,8 +4136,17 @@
             "type": "FIELD",
             "name": "content",
             "content": {
-              "type": "SYMBOL",
-              "name": "paragraph"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "paragraph"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_indent_segment_level_3"
+                }
+              ]
             }
           },
           {
@@ -3922,8 +4173,17 @@
             "type": "FIELD",
             "name": "content",
             "content": {
-              "type": "SYMBOL",
-              "name": "paragraph"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "paragraph"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_indent_segment_level_4"
+                }
+              ]
             }
           },
           {
@@ -3950,8 +4210,17 @@
             "type": "FIELD",
             "name": "content",
             "content": {
-              "type": "SYMBOL",
-              "name": "paragraph"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "paragraph"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_indent_segment_level_5"
+                }
+              ]
             }
           },
           {
@@ -3978,8 +4247,17 @@
             "type": "FIELD",
             "name": "content",
             "content": {
-              "type": "SYMBOL",
-              "name": "paragraph"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "paragraph"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_indent_segment_level_6"
+                }
+              ]
             }
           }
         ]
@@ -3999,8 +4277,17 @@
             "type": "FIELD",
             "name": "content",
             "content": {
-              "type": "SYMBOL",
-              "name": "paragraph"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "paragraph"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_indent_segment_level_1"
+                }
+              ]
             }
           },
           {
@@ -4027,8 +4314,17 @@
             "type": "FIELD",
             "name": "content",
             "content": {
-              "type": "SYMBOL",
-              "name": "paragraph"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "paragraph"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_indent_segment_level_2"
+                }
+              ]
             }
           },
           {
@@ -4055,8 +4351,17 @@
             "type": "FIELD",
             "name": "content",
             "content": {
-              "type": "SYMBOL",
-              "name": "paragraph"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "paragraph"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_indent_segment_level_3"
+                }
+              ]
             }
           },
           {
@@ -4083,8 +4388,17 @@
             "type": "FIELD",
             "name": "content",
             "content": {
-              "type": "SYMBOL",
-              "name": "paragraph"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "paragraph"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_indent_segment_level_4"
+                }
+              ]
             }
           },
           {
@@ -4111,8 +4425,17 @@
             "type": "FIELD",
             "name": "content",
             "content": {
-              "type": "SYMBOL",
-              "name": "paragraph"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "paragraph"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_indent_segment_level_5"
+                }
+              ]
             }
           },
           {
@@ -4139,8 +4462,17 @@
             "type": "FIELD",
             "name": "content",
             "content": {
-              "type": "SYMBOL",
-              "name": "paragraph"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "paragraph"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_indent_segment_level_6"
+                }
+              ]
             }
           }
         ]

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3916,6 +3916,55 @@
         }
       }
     },
+    "indent_segment": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "indent_modifier"
+          },
+          {
+            "type": "REPEAT1",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "paragraph"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_paragraph_break"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "tag"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_any_list_item_level_2"
+                }
+              ]
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "weak_paragraph_delimiter"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
     "unordered_list1": {
       "type": "PREC_RIGHT",
       "value": 0,
@@ -3930,8 +3979,17 @@
             "type": "FIELD",
             "name": "content",
             "content": {
-              "type": "SYMBOL",
-              "name": "paragraph"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "paragraph"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "indent_segment"
+                }
+              ]
             }
           },
           {
@@ -5808,6 +5866,10 @@
     {
       "type": "SYMBOL",
       "name": "ordered_link6_prefix"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "indent_modifier"
     },
     {
       "type": "SYMBOL",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -193,6 +193,10 @@
               "name": "_paragraph_element"
             },
             {
+              "type": "SYMBOL",
+              "name": "ranged_attached_modifier"
+            },
+            {
               "type": "ALIAS",
               "content": {
                 "type": "SYMBOL",
@@ -507,7 +511,16 @@
           "type": "ALIAS",
           "content": {
             "type": "SYMBOL",
-            "name": "ranged_modifier"
+            "name": "ranged_modifier_open"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "ranged_modifier_close"
           },
           "named": false,
           "value": "_lowercase"
@@ -1288,940 +1301,500 @@
         ]
       }
     },
-    "ranged_bold_open": {
-      "type": "PREC_LEFT",
-      "value": 2,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_modifier"
-            },
-            "named": false,
-            "value": "_ranged_modifier"
-          },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "bold_open"
-            },
-            "named": false,
-            "value": "_bold_open"
-          }
-        ]
-      }
-    },
-    "ranged_bold_close": {
-      "type": "PREC_LEFT",
-      "value": 2,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "bold_close"
-            },
-            "named": false,
-            "value": "_bold_close"
-          },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_modifier"
-            },
-            "named": false,
-            "value": "_ranged_modifier"
-          }
-        ]
-      }
-    },
     "ranged_bold": {
-      "type": "PREC_LEFT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_bold_open"
-            },
-            "named": false,
-            "value": "_open"
-          },
-          {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
             "type": "SYMBOL",
-            "name": "_ranged_attached_modifier_content"
+            "name": "ranged_modifier_open"
           },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_bold_close"
-            },
-            "named": false,
-            "value": "_close"
-          }
-        ]
-      }
-    },
-    "ranged_italic_open": {
-      "type": "PREC_LEFT",
-      "value": 2,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_modifier"
-            },
-            "named": false,
-            "value": "_ranged_modifier"
+          "named": false,
+          "value": "_open"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "bold_open"
           },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "italic_open"
-            },
-            "named": false,
-            "value": "_italic_open"
-          }
-        ]
-      }
-    },
-    "ranged_italic_close": {
-      "type": "PREC_LEFT",
-      "value": 2,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "italic_close"
-            },
-            "named": false,
-            "value": "_italic_close"
+          "named": false,
+          "value": "_open"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_ranged_attached_modifier_content"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "bold_close"
           },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_modifier"
-            },
-            "named": false,
-            "value": "_ranged_modifier"
-          }
-        ]
-      }
+          "named": false,
+          "value": "_close"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "ranged_modifier_close"
+          },
+          "named": false,
+          "value": "_close"
+        }
+      ]
     },
     "ranged_italic": {
-      "type": "PREC_LEFT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_italic_open"
-            },
-            "named": false,
-            "value": "_open"
-          },
-          {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
             "type": "SYMBOL",
-            "name": "_ranged_attached_modifier_content"
+            "name": "ranged_modifier_open"
           },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_italic_close"
-            },
-            "named": false,
-            "value": "_close"
-          }
-        ]
-      }
-    },
-    "ranged_strikethrough_open": {
-      "type": "PREC_LEFT",
-      "value": 2,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_modifier"
-            },
-            "named": false,
-            "value": "_ranged_modifier"
+          "named": false,
+          "value": "_open"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "italic_open"
           },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "strikethrough_open"
-            },
-            "named": false,
-            "value": "_strikethrough_open"
-          }
-        ]
-      }
-    },
-    "ranged_strikethrough_close": {
-      "type": "PREC_LEFT",
-      "value": 2,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "strikethrough_close"
-            },
-            "named": false,
-            "value": "_strikethrough_close"
+          "named": false,
+          "value": "_open"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_ranged_attached_modifier_content"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "italic_close"
           },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_modifier"
-            },
-            "named": false,
-            "value": "_ranged_modifier"
-          }
-        ]
-      }
+          "named": false,
+          "value": "_close"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "ranged_modifier_close"
+          },
+          "named": false,
+          "value": "_close"
+        }
+      ]
     },
     "ranged_strikethrough": {
-      "type": "PREC_LEFT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_strikethrough_open"
-            },
-            "named": false,
-            "value": "_open"
-          },
-          {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
             "type": "SYMBOL",
-            "name": "_ranged_attached_modifier_content"
+            "name": "ranged_modifier_open"
           },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_strikethrough_close"
-            },
-            "named": false,
-            "value": "_close"
-          }
-        ]
-      }
-    },
-    "ranged_underline_open": {
-      "type": "PREC_LEFT",
-      "value": 2,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_modifier"
-            },
-            "named": false,
-            "value": "_ranged_modifier"
+          "named": false,
+          "value": "_open"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "strikethrough_open"
           },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "underline_open"
-            },
-            "named": false,
-            "value": "_underline_open"
-          }
-        ]
-      }
-    },
-    "ranged_underline_close": {
-      "type": "PREC_LEFT",
-      "value": 2,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "underline_close"
-            },
-            "named": false,
-            "value": "_underline_close"
+          "named": false,
+          "value": "_open"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_ranged_attached_modifier_content"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "strikethrough_close"
           },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_modifier"
-            },
-            "named": false,
-            "value": "_ranged_modifier"
-          }
-        ]
-      }
+          "named": false,
+          "value": "_close"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "ranged_modifier_close"
+          },
+          "named": false,
+          "value": "_close"
+        }
+      ]
     },
     "ranged_underline": {
-      "type": "PREC_LEFT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_underline_open"
-            },
-            "named": false,
-            "value": "_open"
-          },
-          {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
             "type": "SYMBOL",
-            "name": "_ranged_attached_modifier_content"
+            "name": "ranged_modifier_open"
           },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_underline_close"
-            },
-            "named": false,
-            "value": "_close"
-          }
-        ]
-      }
-    },
-    "ranged_spoiler_open": {
-      "type": "PREC_LEFT",
-      "value": 2,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_modifier"
-            },
-            "named": false,
-            "value": "_ranged_modifier"
+          "named": false,
+          "value": "_open"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "underline_open"
           },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "spoiler_open"
-            },
-            "named": false,
-            "value": "_spoiler_open"
-          }
-        ]
-      }
-    },
-    "ranged_spoiler_close": {
-      "type": "PREC_LEFT",
-      "value": 2,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "spoiler_close"
-            },
-            "named": false,
-            "value": "_spoiler_close"
+          "named": false,
+          "value": "_open"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_ranged_attached_modifier_content"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "underline_close"
           },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_modifier"
-            },
-            "named": false,
-            "value": "_ranged_modifier"
-          }
-        ]
-      }
+          "named": false,
+          "value": "_close"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "ranged_modifier_close"
+          },
+          "named": false,
+          "value": "_close"
+        }
+      ]
     },
     "ranged_spoiler": {
-      "type": "PREC_LEFT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_spoiler_open"
-            },
-            "named": false,
-            "value": "_open"
-          },
-          {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
             "type": "SYMBOL",
-            "name": "_ranged_attached_modifier_content"
+            "name": "ranged_modifier_open"
           },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_spoiler_close"
-            },
-            "named": false,
-            "value": "_close"
-          }
-        ]
-      }
-    },
-    "ranged_superscript_open": {
-      "type": "PREC_LEFT",
-      "value": 2,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_modifier"
-            },
-            "named": false,
-            "value": "_ranged_modifier"
+          "named": false,
+          "value": "_open"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "spoiler_open"
           },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "superscript_open"
-            },
-            "named": false,
-            "value": "_superscript_open"
-          }
-        ]
-      }
-    },
-    "ranged_superscript_close": {
-      "type": "PREC_LEFT",
-      "value": 2,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "superscript_close"
-            },
-            "named": false,
-            "value": "_superscript_close"
+          "named": false,
+          "value": "_open"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_ranged_attached_modifier_content"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "spoiler_close"
           },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_modifier"
-            },
-            "named": false,
-            "value": "_ranged_modifier"
-          }
-        ]
-      }
+          "named": false,
+          "value": "_close"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "ranged_modifier_close"
+          },
+          "named": false,
+          "value": "_close"
+        }
+      ]
     },
     "ranged_superscript": {
-      "type": "PREC_LEFT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_superscript_open"
-            },
-            "named": false,
-            "value": "_open"
-          },
-          {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
             "type": "SYMBOL",
-            "name": "_ranged_attached_modifier_content"
+            "name": "ranged_modifier_open"
           },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_superscript_close"
-            },
-            "named": false,
-            "value": "_close"
-          }
-        ]
-      }
-    },
-    "ranged_subscript_open": {
-      "type": "PREC_LEFT",
-      "value": 2,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_modifier"
-            },
-            "named": false,
-            "value": "_ranged_modifier"
+          "named": false,
+          "value": "_open"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "superscript_open"
           },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "subscript_open"
-            },
-            "named": false,
-            "value": "_subscript_open"
-          }
-        ]
-      }
-    },
-    "ranged_subscript_close": {
-      "type": "PREC_LEFT",
-      "value": 2,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "subscript_close"
-            },
-            "named": false,
-            "value": "_subscript_close"
+          "named": false,
+          "value": "_open"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_ranged_attached_modifier_content"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "superscript_close"
           },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_modifier"
-            },
-            "named": false,
-            "value": "_ranged_modifier"
-          }
-        ]
-      }
+          "named": false,
+          "value": "_close"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "ranged_modifier_close"
+          },
+          "named": false,
+          "value": "_close"
+        }
+      ]
     },
     "ranged_subscript": {
-      "type": "PREC_LEFT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_subscript_open"
-            },
-            "named": false,
-            "value": "_open"
-          },
-          {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
             "type": "SYMBOL",
-            "name": "_ranged_attached_modifier_content"
+            "name": "ranged_modifier_open"
           },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_subscript_close"
-            },
-            "named": false,
-            "value": "_close"
-          }
-        ]
-      }
-    },
-    "ranged_verbatim_open": {
-      "type": "PREC_LEFT",
-      "value": 2,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_modifier"
-            },
-            "named": false,
-            "value": "_ranged_modifier"
+          "named": false,
+          "value": "_open"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "subscript_open"
           },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "verbatim_open"
-            },
-            "named": false,
-            "value": "_verbatim_open"
-          }
-        ]
-      }
-    },
-    "ranged_verbatim_close": {
-      "type": "PREC_LEFT",
-      "value": 2,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "verbatim_close"
-            },
-            "named": false,
-            "value": "_verbatim_close"
+          "named": false,
+          "value": "_open"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_ranged_attached_modifier_content"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "subscript_close"
           },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_modifier"
-            },
-            "named": false,
-            "value": "_ranged_modifier"
-          }
-        ]
-      }
+          "named": false,
+          "value": "_close"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "ranged_modifier_close"
+          },
+          "named": false,
+          "value": "_close"
+        }
+      ]
     },
     "ranged_verbatim": {
-      "type": "PREC_LEFT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_verbatim_open"
-            },
-            "named": false,
-            "value": "_open"
-          },
-          {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
             "type": "SYMBOL",
-            "name": "_ranged_verbatim_attached_modifier_content"
+            "name": "ranged_modifier_open"
           },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_verbatim_close"
-            },
-            "named": false,
-            "value": "_close"
-          }
-        ]
-      }
-    },
-    "ranged_inline_comment_open": {
-      "type": "PREC_LEFT",
-      "value": 2,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_modifier"
-            },
-            "named": false,
-            "value": "_ranged_modifier"
+          "named": false,
+          "value": "_open"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "verbatim_open"
           },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "inline_comment_open"
-            },
-            "named": false,
-            "value": "_inline_comment_open"
-          }
-        ]
-      }
-    },
-    "ranged_inline_comment_close": {
-      "type": "PREC_LEFT",
-      "value": 2,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "inline_comment_close"
-            },
-            "named": false,
-            "value": "_inline_comment_close"
+          "named": false,
+          "value": "_open"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_ranged_verbatim_attached_modifier_content"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "verbatim_close"
           },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_modifier"
-            },
-            "named": false,
-            "value": "_ranged_modifier"
-          }
-        ]
-      }
+          "named": false,
+          "value": "_close"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "ranged_modifier_close"
+          },
+          "named": false,
+          "value": "_close"
+        }
+      ]
     },
     "ranged_inline_comment": {
-      "type": "PREC_LEFT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_inline_comment_open"
-            },
-            "named": false,
-            "value": "_open"
-          },
-          {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
             "type": "SYMBOL",
-            "name": "_ranged_verbatim_attached_modifier_content"
+            "name": "ranged_modifier_open"
           },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_inline_comment_close"
-            },
-            "named": false,
-            "value": "_close"
-          }
-        ]
-      }
-    },
-    "ranged_inline_math_open": {
-      "type": "PREC_LEFT",
-      "value": 2,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_modifier"
-            },
-            "named": false,
-            "value": "_ranged_modifier"
+          "named": false,
+          "value": "_open"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "inline_comment_open"
           },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "inline_math_open"
-            },
-            "named": false,
-            "value": "_inline_math_open"
-          }
-        ]
-      }
-    },
-    "ranged_inline_math_close": {
-      "type": "PREC_LEFT",
-      "value": 2,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "inline_math_close"
-            },
-            "named": false,
-            "value": "_inline_math_close"
+          "named": false,
+          "value": "_open"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_ranged_verbatim_attached_modifier_content"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "inline_comment_close"
           },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_modifier"
-            },
-            "named": false,
-            "value": "_ranged_modifier"
-          }
-        ]
-      }
+          "named": false,
+          "value": "_close"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "ranged_modifier_close"
+          },
+          "named": false,
+          "value": "_close"
+        }
+      ]
     },
     "ranged_inline_math": {
-      "type": "PREC_LEFT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_inline_math_open"
-            },
-            "named": false,
-            "value": "_open"
-          },
-          {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
             "type": "SYMBOL",
-            "name": "_ranged_verbatim_attached_modifier_content"
+            "name": "ranged_modifier_open"
           },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_inline_math_close"
-            },
-            "named": false,
-            "value": "_close"
-          }
-        ]
-      }
-    },
-    "ranged_variable_open": {
-      "type": "PREC_LEFT",
-      "value": 2,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_modifier"
-            },
-            "named": false,
-            "value": "_ranged_modifier"
+          "named": false,
+          "value": "_open"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "inline_math_open"
           },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "variable_open"
-            },
-            "named": false,
-            "value": "_variable_open"
-          }
-        ]
-      }
-    },
-    "ranged_variable_close": {
-      "type": "PREC_LEFT",
-      "value": 2,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "variable_close"
-            },
-            "named": false,
-            "value": "_variable_close"
+          "named": false,
+          "value": "_open"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_ranged_verbatim_attached_modifier_content"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "inline_math_close"
           },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_modifier"
-            },
-            "named": false,
-            "value": "_ranged_modifier"
-          }
-        ]
-      }
+          "named": false,
+          "value": "_close"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "ranged_modifier_close"
+          },
+          "named": false,
+          "value": "_close"
+        }
+      ]
     },
     "ranged_variable": {
-      "type": "PREC_LEFT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_variable_open"
-            },
-            "named": false,
-            "value": "_open"
-          },
-          {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
             "type": "SYMBOL",
-            "name": "_ranged_verbatim_attached_modifier_content"
+            "name": "ranged_modifier_open"
           },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "ranged_variable_close"
-            },
-            "named": false,
-            "value": "_close"
-          }
-        ]
-      }
+          "named": false,
+          "value": "_open"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "variable_open"
+          },
+          "named": false,
+          "value": "_open"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_ranged_verbatim_attached_modifier_content"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "variable_close"
+          },
+          "named": false,
+          "value": "_close"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "ranged_modifier_close"
+          },
+          "named": false,
+          "value": "_close"
+        }
+      ]
     },
     "any_char": {
       "type": "IMMEDIATE_TOKEN",
@@ -6330,10 +5903,6 @@
     },
     {
       "type": "SYMBOL",
-      "name": "ranged_modifier"
-    },
-    {
-      "type": "SYMBOL",
       "name": "bold_open"
     },
     {
@@ -6419,6 +5988,14 @@
     {
       "type": "SYMBOL",
       "name": "variable_close"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "ranged_modifier_open"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "ranged_modifier_close"
     }
   ],
   "inline": [],

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -81,6 +81,109 @@
         }
       ]
     },
+    "paragraph": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "REPEAT1",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "paragraph_segment"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_line_break"
+                }
+              ]
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_paragraph_break"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "paragraph_segment": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "REPEAT1",
+        "content": {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_paragraph_element"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_conflict_open"
+              },
+              "named": false,
+              "value": "_lowercase"
+            }
+          ]
+        }
+      }
+    },
+    "_attached_modifier_content": {
+      "type": "PREC_RIGHT",
+      "value": 1,
+      "content": {
+        "type": "REPEAT1",
+        "content": {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_paragraph_element"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_conflict_open"
+              },
+              "named": false,
+              "value": "_lowercase"
+            }
+          ]
+        }
+      }
+    },
+    "_verbatim_modifier_content": {
+      "type": "PREC_RIGHT",
+      "value": 1,
+      "content": {
+        "type": "REPEAT1",
+        "content": {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_verbatim_paragraph_element"
+            }
+          ]
+        }
+      }
+    },
     "_linked_attached_modifier": {
       "type": "PREC_RIGHT",
       "value": 2,
@@ -109,31 +212,6 @@
               {
                 "type": "SYMBOL",
                 "name": "link_modifier"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "_paragraph": {
-      "type": "PREC_RIGHT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "paragraph"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_paragraph_break"
               },
               {
                 "type": "BLANK"
@@ -307,514 +385,433 @@
         }
       ]
     },
-    "_multi_paragraph_element": {
-      "type": "REPEAT1",
-      "content": {
-        "type": "CHOICE",
-        "members": [
-          {
+    "_verbatim_paragraph_element": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
             "type": "SYMBOL",
-            "name": "_line_break"
+            "name": "word"
           },
-          {
+          "named": false,
+          "value": "_word"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
             "type": "SYMBOL",
-            "name": "_paragraph_element"
+            "name": "space"
           },
-          {
+          "named": false,
+          "value": "_space"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
             "type": "SYMBOL",
-            "name": "_conflict_open"
-          }
-        ]
-      }
-    },
-    "_verbatim_segment": {
-      "type": "PREC_LEFT",
-      "value": 1,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "REPEAT1",
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_line_break"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "word"
-                  },
-                  "named": false,
-                  "value": "_word"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "space"
-                  },
-                  "named": false,
-                  "value": "_space"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "trailing_modifier"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "escape_sequence_prefix"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "any_char"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "link_modifier"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "bold_open"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "bold_close"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "italic_open"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "italic_close"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "strikethrough_open"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "strikethrough_close"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "underline_open"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "underline_close"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "spoiler_open"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "spoiler_close"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "superscript_open"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "superscript_close"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "subscript_open"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "subscript_close"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "verbatim_open"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "verbatim_close"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "inline_comment_open"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "inline_comment_close"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "inline_math_open"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "inline_math_close"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "variable_open"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "variable_close"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "link_description_begin"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "link_description_end"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "link_location_begin"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "link_location_end"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "link_file_begin"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "link_file_end"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "link_file_text"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "link_target_url"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "link_target_generic"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "link_target_external_file"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "link_target_marker"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "link_target_definition"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "link_target_footnote"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "link_target_heading1"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "link_target_heading2"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "link_target_heading3"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "link_target_heading4"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "link_target_heading5"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "link_target_heading6"
-                  },
-                  "named": false,
-                  "value": "_lowercase"
-                }
-              ]
-            }
-          }
-        ]
-      }
-    },
-    "paragraph_segment": {
-      "type": "PREC_RIGHT",
-      "value": 0,
-      "content": {
-        "type": "REPEAT1",
-        "content": {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_paragraph_element"
-            },
-            {
-              "type": "ALIAS",
-              "content": {
-                "type": "SYMBOL",
-                "name": "_conflict_open"
-              },
-              "named": false,
-              "value": "_lowercase"
-            }
-          ]
+            "name": "trailing_modifier"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "escape_sequence_prefix"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "any_char"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "link_modifier"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "bold_open"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "bold_close"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "italic_open"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "italic_close"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "strikethrough_open"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "strikethrough_close"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "underline_open"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "underline_close"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "spoiler_open"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "spoiler_close"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "superscript_open"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "superscript_close"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "subscript_open"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "subscript_close"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "verbatim_open"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "verbatim_close"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "inline_comment_open"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "inline_comment_close"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "inline_math_open"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "inline_math_close"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "variable_open"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "variable_close"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "link_description_begin"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "link_description_end"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "link_location_begin"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "link_location_end"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "link_file_begin"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "link_file_end"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "link_file_text"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "link_target_url"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "link_target_generic"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "link_target_external_file"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "link_target_marker"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "link_target_definition"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "link_target_footnote"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "link_target_heading1"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "link_target_heading2"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "link_target_heading3"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "link_target_heading4"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "link_target_heading5"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "link_target_heading6"
+          },
+          "named": false,
+          "value": "_lowercase"
         }
-      }
-    },
-    "paragraph": {
-      "type": "PREC_RIGHT",
-      "value": 0,
-      "content": {
-        "type": "REPEAT1",
-        "content": {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "paragraph_segment"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_line_break"
-            }
-          ]
-        }
-      }
+      ]
     },
     "bold": {
       "type": "SEQ",
@@ -830,7 +827,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_multi_paragraph_element"
+          "name": "_attached_modifier_content"
         },
         {
           "type": "ALIAS",
@@ -857,7 +854,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_multi_paragraph_element"
+          "name": "_attached_modifier_content"
         },
         {
           "type": "ALIAS",
@@ -884,7 +881,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_multi_paragraph_element"
+          "name": "_attached_modifier_content"
         },
         {
           "type": "ALIAS",
@@ -911,7 +908,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_multi_paragraph_element"
+          "name": "_attached_modifier_content"
         },
         {
           "type": "ALIAS",
@@ -938,7 +935,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_multi_paragraph_element"
+          "name": "_attached_modifier_content"
         },
         {
           "type": "ALIAS",
@@ -965,7 +962,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_verbatim_segment"
+          "name": "_verbatim_modifier_content"
         },
         {
           "type": "ALIAS",
@@ -992,7 +989,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_multi_paragraph_element"
+          "name": "_attached_modifier_content"
         },
         {
           "type": "ALIAS",
@@ -1019,7 +1016,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_multi_paragraph_element"
+          "name": "_attached_modifier_content"
         },
         {
           "type": "ALIAS",
@@ -1046,7 +1043,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_verbatim_segment"
+          "name": "_verbatim_modifier_content"
         },
         {
           "type": "ALIAS",
@@ -1073,7 +1070,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_verbatim_segment"
+          "name": "_verbatim_modifier_content"
         },
         {
           "type": "ALIAS",
@@ -1100,7 +1097,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_verbatim_segment"
+          "name": "_verbatim_modifier_content"
         },
         {
           "type": "ALIAS",
@@ -1462,7 +1459,7 @@
             "type": "ALIAS",
             "content": {
               "type": "SYMBOL",
-              "name": "_verbatim_segment"
+              "name": "_verbatim_modifier_content"
             },
             "named": true,
             "value": "paragraph_segment"
@@ -2285,7 +2282,7 @@
                 "members": [
                   {
                     "type": "SYMBOL",
-                    "name": "_paragraph"
+                    "name": "paragraph"
                   },
                   {
                     "type": "SYMBOL",
@@ -2398,7 +2395,7 @@
                 "members": [
                   {
                     "type": "SYMBOL",
-                    "name": "_paragraph"
+                    "name": "paragraph"
                   },
                   {
                     "type": "SYMBOL",
@@ -2498,7 +2495,7 @@
                 "members": [
                   {
                     "type": "SYMBOL",
-                    "name": "_paragraph"
+                    "name": "paragraph"
                   },
                   {
                     "type": "SYMBOL",
@@ -2594,7 +2591,7 @@
                 "members": [
                   {
                     "type": "SYMBOL",
-                    "name": "_paragraph"
+                    "name": "paragraph"
                   },
                   {
                     "type": "SYMBOL",
@@ -2686,7 +2683,7 @@
                 "members": [
                   {
                     "type": "SYMBOL",
-                    "name": "_paragraph"
+                    "name": "paragraph"
                   },
                   {
                     "type": "SYMBOL",
@@ -2774,7 +2771,7 @@
                 "members": [
                   {
                     "type": "SYMBOL",
-                    "name": "_paragraph"
+                    "name": "paragraph"
                   },
                   {
                     "type": "SYMBOL",
@@ -3714,7 +3711,7 @@
                 "members": [
                   {
                     "type": "SYMBOL",
-                    "name": "_paragraph"
+                    "name": "paragraph"
                   },
                   {
                     "type": "SYMBOL",
@@ -4170,7 +4167,7 @@
                   "members": [
                     {
                       "type": "SYMBOL",
-                      "name": "_paragraph"
+                      "name": "paragraph"
                     },
                     {
                       "type": "SYMBOL",
@@ -4274,7 +4271,7 @@
                   "members": [
                     {
                       "type": "SYMBOL",
-                      "name": "_paragraph"
+                      "name": "paragraph"
                     },
                     {
                       "type": "SYMBOL",
@@ -4491,7 +4488,7 @@
               "members": [
                 {
                   "type": "SYMBOL",
-                  "name": "_paragraph"
+                  "name": "paragraph"
                 },
                 {
                   "type": "REPEAT1",
@@ -4806,10 +4803,6 @@
         },
         {
           "type": "SYMBOL",
-          "name": "verbatim"
-        },
-        {
-          "type": "SYMBOL",
           "name": "spoiler"
         },
         {
@@ -4819,6 +4812,10 @@
         {
           "type": "SYMBOL",
           "name": "subscript"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "verbatim"
         },
         {
           "type": "SYMBOL",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -131,6 +131,10 @@
               "name": "_paragraph_element"
             },
             {
+              "type": "SYMBOL",
+              "name": "ranged_attached_modifier"
+            },
+            {
               "type": "ALIAS",
               "content": {
                 "type": "SYMBOL",
@@ -168,6 +172,39 @@
         }
       }
     },
+    "_ranged_attached_modifier_content": {
+      "type": "PREC_RIGHT",
+      "value": 1,
+      "content": {
+        "type": "REPEAT1",
+        "content": {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_paragraph_break"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_line_break"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_paragraph_element"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_conflict_open"
+              },
+              "named": false,
+              "value": "_lowercase"
+            }
+          ]
+        }
+      }
+    },
     "_verbatim_modifier_content": {
       "type": "PREC_RIGHT",
       "value": 1,
@@ -176,6 +213,30 @@
         "content": {
           "type": "CHOICE",
           "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_verbatim_paragraph_element"
+            }
+          ]
+        }
+      }
+    },
+    "_ranged_verbatim_attached_modifier_content": {
+      "type": "PREC_RIGHT",
+      "value": 1,
+      "content": {
+        "type": "REPEAT1",
+        "content": {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_paragraph_break"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_line_break"
+            },
             {
               "type": "SYMBOL",
               "name": "_verbatim_paragraph_element"
@@ -438,6 +499,15 @@
           "content": {
             "type": "SYMBOL",
             "name": "link_modifier"
+          },
+          "named": false,
+          "value": "_lowercase"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "ranged_modifier"
           },
           "named": false,
           "value": "_lowercase"
@@ -1214,6 +1284,941 @@
             },
             "named": false,
             "value": "_lowercase"
+          }
+        ]
+      }
+    },
+    "ranged_bold_open": {
+      "type": "PREC_LEFT",
+      "value": 2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_modifier"
+            },
+            "named": false,
+            "value": "_ranged_modifier"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "bold_open"
+            },
+            "named": false,
+            "value": "_bold_open"
+          }
+        ]
+      }
+    },
+    "ranged_bold_close": {
+      "type": "PREC_LEFT",
+      "value": 2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "bold_close"
+            },
+            "named": false,
+            "value": "_bold_close"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_modifier"
+            },
+            "named": false,
+            "value": "_ranged_modifier"
+          }
+        ]
+      }
+    },
+    "ranged_bold": {
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_bold_open"
+            },
+            "named": false,
+            "value": "_open"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_ranged_attached_modifier_content"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_bold_close"
+            },
+            "named": false,
+            "value": "_close"
+          }
+        ]
+      }
+    },
+    "ranged_italic_open": {
+      "type": "PREC_LEFT",
+      "value": 2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_modifier"
+            },
+            "named": false,
+            "value": "_ranged_modifier"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "italic_open"
+            },
+            "named": false,
+            "value": "_italic_open"
+          }
+        ]
+      }
+    },
+    "ranged_italic_close": {
+      "type": "PREC_LEFT",
+      "value": 2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "italic_close"
+            },
+            "named": false,
+            "value": "_italic_close"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_modifier"
+            },
+            "named": false,
+            "value": "_ranged_modifier"
+          }
+        ]
+      }
+    },
+    "ranged_italic": {
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_italic_open"
+            },
+            "named": false,
+            "value": "_open"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_ranged_attached_modifier_content"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_italic_close"
+            },
+            "named": false,
+            "value": "_close"
+          }
+        ]
+      }
+    },
+    "ranged_strikethrough_open": {
+      "type": "PREC_LEFT",
+      "value": 2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_modifier"
+            },
+            "named": false,
+            "value": "_ranged_modifier"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "strikethrough_open"
+            },
+            "named": false,
+            "value": "_strikethrough_open"
+          }
+        ]
+      }
+    },
+    "ranged_strikethrough_close": {
+      "type": "PREC_LEFT",
+      "value": 2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "strikethrough_close"
+            },
+            "named": false,
+            "value": "_strikethrough_close"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_modifier"
+            },
+            "named": false,
+            "value": "_ranged_modifier"
+          }
+        ]
+      }
+    },
+    "ranged_strikethrough": {
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_strikethrough_open"
+            },
+            "named": false,
+            "value": "_open"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_ranged_attached_modifier_content"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_strikethrough_close"
+            },
+            "named": false,
+            "value": "_close"
+          }
+        ]
+      }
+    },
+    "ranged_underline_open": {
+      "type": "PREC_LEFT",
+      "value": 2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_modifier"
+            },
+            "named": false,
+            "value": "_ranged_modifier"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "underline_open"
+            },
+            "named": false,
+            "value": "_underline_open"
+          }
+        ]
+      }
+    },
+    "ranged_underline_close": {
+      "type": "PREC_LEFT",
+      "value": 2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "underline_close"
+            },
+            "named": false,
+            "value": "_underline_close"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_modifier"
+            },
+            "named": false,
+            "value": "_ranged_modifier"
+          }
+        ]
+      }
+    },
+    "ranged_underline": {
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_underline_open"
+            },
+            "named": false,
+            "value": "_open"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_ranged_attached_modifier_content"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_underline_close"
+            },
+            "named": false,
+            "value": "_close"
+          }
+        ]
+      }
+    },
+    "ranged_spoiler_open": {
+      "type": "PREC_LEFT",
+      "value": 2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_modifier"
+            },
+            "named": false,
+            "value": "_ranged_modifier"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "spoiler_open"
+            },
+            "named": false,
+            "value": "_spoiler_open"
+          }
+        ]
+      }
+    },
+    "ranged_spoiler_close": {
+      "type": "PREC_LEFT",
+      "value": 2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "spoiler_close"
+            },
+            "named": false,
+            "value": "_spoiler_close"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_modifier"
+            },
+            "named": false,
+            "value": "_ranged_modifier"
+          }
+        ]
+      }
+    },
+    "ranged_spoiler": {
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_spoiler_open"
+            },
+            "named": false,
+            "value": "_open"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_ranged_attached_modifier_content"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_spoiler_close"
+            },
+            "named": false,
+            "value": "_close"
+          }
+        ]
+      }
+    },
+    "ranged_superscript_open": {
+      "type": "PREC_LEFT",
+      "value": 2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_modifier"
+            },
+            "named": false,
+            "value": "_ranged_modifier"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "superscript_open"
+            },
+            "named": false,
+            "value": "_superscript_open"
+          }
+        ]
+      }
+    },
+    "ranged_superscript_close": {
+      "type": "PREC_LEFT",
+      "value": 2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "superscript_close"
+            },
+            "named": false,
+            "value": "_superscript_close"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_modifier"
+            },
+            "named": false,
+            "value": "_ranged_modifier"
+          }
+        ]
+      }
+    },
+    "ranged_superscript": {
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_superscript_open"
+            },
+            "named": false,
+            "value": "_open"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_ranged_attached_modifier_content"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_superscript_close"
+            },
+            "named": false,
+            "value": "_close"
+          }
+        ]
+      }
+    },
+    "ranged_subscript_open": {
+      "type": "PREC_LEFT",
+      "value": 2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_modifier"
+            },
+            "named": false,
+            "value": "_ranged_modifier"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "subscript_open"
+            },
+            "named": false,
+            "value": "_subscript_open"
+          }
+        ]
+      }
+    },
+    "ranged_subscript_close": {
+      "type": "PREC_LEFT",
+      "value": 2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "subscript_close"
+            },
+            "named": false,
+            "value": "_subscript_close"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_modifier"
+            },
+            "named": false,
+            "value": "_ranged_modifier"
+          }
+        ]
+      }
+    },
+    "ranged_subscript": {
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_subscript_open"
+            },
+            "named": false,
+            "value": "_open"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_ranged_attached_modifier_content"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_subscript_close"
+            },
+            "named": false,
+            "value": "_close"
+          }
+        ]
+      }
+    },
+    "ranged_verbatim_open": {
+      "type": "PREC_LEFT",
+      "value": 2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_modifier"
+            },
+            "named": false,
+            "value": "_ranged_modifier"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "verbatim_open"
+            },
+            "named": false,
+            "value": "_verbatim_open"
+          }
+        ]
+      }
+    },
+    "ranged_verbatim_close": {
+      "type": "PREC_LEFT",
+      "value": 2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "verbatim_close"
+            },
+            "named": false,
+            "value": "_verbatim_close"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_modifier"
+            },
+            "named": false,
+            "value": "_ranged_modifier"
+          }
+        ]
+      }
+    },
+    "ranged_verbatim": {
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_verbatim_open"
+            },
+            "named": false,
+            "value": "_open"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_ranged_verbatim_attached_modifier_content"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_verbatim_close"
+            },
+            "named": false,
+            "value": "_close"
+          }
+        ]
+      }
+    },
+    "ranged_inline_comment_open": {
+      "type": "PREC_LEFT",
+      "value": 2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_modifier"
+            },
+            "named": false,
+            "value": "_ranged_modifier"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "inline_comment_open"
+            },
+            "named": false,
+            "value": "_inline_comment_open"
+          }
+        ]
+      }
+    },
+    "ranged_inline_comment_close": {
+      "type": "PREC_LEFT",
+      "value": 2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "inline_comment_close"
+            },
+            "named": false,
+            "value": "_inline_comment_close"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_modifier"
+            },
+            "named": false,
+            "value": "_ranged_modifier"
+          }
+        ]
+      }
+    },
+    "ranged_inline_comment": {
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_inline_comment_open"
+            },
+            "named": false,
+            "value": "_open"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_ranged_verbatim_attached_modifier_content"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_inline_comment_close"
+            },
+            "named": false,
+            "value": "_close"
+          }
+        ]
+      }
+    },
+    "ranged_inline_math_open": {
+      "type": "PREC_LEFT",
+      "value": 2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_modifier"
+            },
+            "named": false,
+            "value": "_ranged_modifier"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "inline_math_open"
+            },
+            "named": false,
+            "value": "_inline_math_open"
+          }
+        ]
+      }
+    },
+    "ranged_inline_math_close": {
+      "type": "PREC_LEFT",
+      "value": 2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "inline_math_close"
+            },
+            "named": false,
+            "value": "_inline_math_close"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_modifier"
+            },
+            "named": false,
+            "value": "_ranged_modifier"
+          }
+        ]
+      }
+    },
+    "ranged_inline_math": {
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_inline_math_open"
+            },
+            "named": false,
+            "value": "_open"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_ranged_verbatim_attached_modifier_content"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_inline_math_close"
+            },
+            "named": false,
+            "value": "_close"
+          }
+        ]
+      }
+    },
+    "ranged_variable_open": {
+      "type": "PREC_LEFT",
+      "value": 2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_modifier"
+            },
+            "named": false,
+            "value": "_ranged_modifier"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "variable_open"
+            },
+            "named": false,
+            "value": "_variable_open"
+          }
+        ]
+      }
+    },
+    "ranged_variable_close": {
+      "type": "PREC_LEFT",
+      "value": 2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "variable_close"
+            },
+            "named": false,
+            "value": "_variable_close"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_modifier"
+            },
+            "named": false,
+            "value": "_ranged_modifier"
+          }
+        ]
+      }
+    },
+    "ranged_variable": {
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_variable_open"
+            },
+            "named": false,
+            "value": "_open"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_ranged_verbatim_attached_modifier_content"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ranged_variable_close"
+            },
+            "named": false,
+            "value": "_close"
           }
         ]
       }
@@ -4830,6 +5835,55 @@
           "name": "variable"
         }
       ]
+    },
+    "ranged_attached_modifier": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "ranged_bold"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ranged_italic"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ranged_strikethrough"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ranged_underline"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ranged_spoiler"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ranged_superscript"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ranged_subscript"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ranged_verbatim"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ranged_inline_comment"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ranged_inline_math"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ranged_variable"
+        }
+      ]
     }
   },
   "extras": [
@@ -5276,6 +6330,10 @@
     },
     {
       "type": "SYMBOL",
+      "name": "ranged_modifier"
+    },
+    {
+      "type": "SYMBOL",
       "name": "bold_open"
     },
     {
@@ -5366,6 +6424,7 @@
   "inline": [],
   "supertypes": [
     "attached_modifier",
+    "ranged_attached_modifier",
     "heading",
     "detached_modifier",
     "footnote",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -102,18 +102,6 @@
                 }
               ]
             }
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_paragraph_break"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
           }
         ]
       }
@@ -3445,7 +3433,7 @@
             "name": "content",
             "content": {
               "type": "SYMBOL",
-              "name": "paragraph_segment"
+              "name": "paragraph"
             }
           },
           {
@@ -3510,7 +3498,7 @@
             "name": "content",
             "content": {
               "type": "SYMBOL",
-              "name": "paragraph_segment"
+              "name": "paragraph"
             }
           },
           {
@@ -3571,7 +3559,7 @@
             "name": "content",
             "content": {
               "type": "SYMBOL",
-              "name": "paragraph_segment"
+              "name": "paragraph"
             }
           },
           {
@@ -3628,7 +3616,7 @@
             "name": "content",
             "content": {
               "type": "SYMBOL",
-              "name": "paragraph_segment"
+              "name": "paragraph"
             }
           },
           {
@@ -3681,7 +3669,7 @@
             "name": "content",
             "content": {
               "type": "SYMBOL",
-              "name": "paragraph_segment"
+              "name": "paragraph"
             }
           },
           {
@@ -3725,7 +3713,7 @@
             "name": "content",
             "content": {
               "type": "SYMBOL",
-              "name": "paragraph_segment"
+              "name": "paragraph"
             }
           },
           {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -182,6 +182,10 @@
             },
             {
               "type": "SYMBOL",
+              "name": "_ranged_attached_modifier"
+            },
+            {
+              "type": "SYMBOL",
               "name": "ranged_attached_modifier"
             },
             {
@@ -213,7 +217,7 @@
         }
       }
     },
-    "_ranged_verbatim_attached_modifier_content": {
+    "_ranged_verbatim_modifier_content": {
       "type": "PREC_RIGHT",
       "value": 1,
       "content": {
@@ -885,301 +889,345 @@
       ]
     },
     "bold": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "bold_open"
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "bold_open"
+            },
+            "named": false,
+            "value": "_open"
           },
-          "named": false,
-          "value": "_open"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_attached_modifier_content"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
+          {
             "type": "SYMBOL",
-            "name": "bold_close"
+            "name": "_attached_modifier_content"
           },
-          "named": false,
-          "value": "_close"
-        }
-      ]
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "bold_close"
+            },
+            "named": false,
+            "value": "_close"
+          }
+        ]
+      }
     },
     "italic": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "italic_open"
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "italic_open"
+            },
+            "named": false,
+            "value": "_open"
           },
-          "named": false,
-          "value": "_open"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_attached_modifier_content"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
+          {
             "type": "SYMBOL",
-            "name": "italic_close"
+            "name": "_attached_modifier_content"
           },
-          "named": false,
-          "value": "_close"
-        }
-      ]
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "italic_close"
+            },
+            "named": false,
+            "value": "_close"
+          }
+        ]
+      }
     },
     "strikethrough": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "strikethrough_open"
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "strikethrough_open"
+            },
+            "named": false,
+            "value": "_open"
           },
-          "named": false,
-          "value": "_open"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_attached_modifier_content"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
+          {
             "type": "SYMBOL",
-            "name": "strikethrough_close"
+            "name": "_attached_modifier_content"
           },
-          "named": false,
-          "value": "_close"
-        }
-      ]
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "strikethrough_close"
+            },
+            "named": false,
+            "value": "_close"
+          }
+        ]
+      }
     },
     "underline": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "underline_open"
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "underline_open"
+            },
+            "named": false,
+            "value": "_open"
           },
-          "named": false,
-          "value": "_open"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_attached_modifier_content"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
+          {
             "type": "SYMBOL",
-            "name": "underline_close"
+            "name": "_attached_modifier_content"
           },
-          "named": false,
-          "value": "_close"
-        }
-      ]
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "underline_close"
+            },
+            "named": false,
+            "value": "_close"
+          }
+        ]
+      }
     },
     "spoiler": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "spoiler_open"
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "spoiler_open"
+            },
+            "named": false,
+            "value": "_open"
           },
-          "named": false,
-          "value": "_open"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_attached_modifier_content"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
+          {
             "type": "SYMBOL",
-            "name": "spoiler_close"
+            "name": "_attached_modifier_content"
           },
-          "named": false,
-          "value": "_close"
-        }
-      ]
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "spoiler_close"
+            },
+            "named": false,
+            "value": "_close"
+          }
+        ]
+      }
     },
     "verbatim": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "verbatim_open"
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "verbatim_open"
+            },
+            "named": false,
+            "value": "_open"
           },
-          "named": false,
-          "value": "_open"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_verbatim_modifier_content"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
+          {
             "type": "SYMBOL",
-            "name": "verbatim_close"
+            "name": "_verbatim_modifier_content"
           },
-          "named": false,
-          "value": "_close"
-        }
-      ]
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "verbatim_close"
+            },
+            "named": false,
+            "value": "_close"
+          }
+        ]
+      }
     },
     "superscript": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "superscript_open"
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "superscript_open"
+            },
+            "named": false,
+            "value": "_open"
           },
-          "named": false,
-          "value": "_open"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_attached_modifier_content"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
+          {
             "type": "SYMBOL",
-            "name": "superscript_close"
+            "name": "_attached_modifier_content"
           },
-          "named": false,
-          "value": "_close"
-        }
-      ]
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "superscript_close"
+            },
+            "named": false,
+            "value": "_close"
+          }
+        ]
+      }
     },
     "subscript": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "subscript_open"
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "subscript_open"
+            },
+            "named": false,
+            "value": "_open"
           },
-          "named": false,
-          "value": "_open"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_attached_modifier_content"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
+          {
             "type": "SYMBOL",
-            "name": "subscript_close"
+            "name": "_attached_modifier_content"
           },
-          "named": false,
-          "value": "_close"
-        }
-      ]
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "subscript_close"
+            },
+            "named": false,
+            "value": "_close"
+          }
+        ]
+      }
     },
     "inline_comment": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "inline_comment_open"
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "inline_comment_open"
+            },
+            "named": false,
+            "value": "_open"
           },
-          "named": false,
-          "value": "_open"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_verbatim_modifier_content"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
+          {
             "type": "SYMBOL",
-            "name": "inline_comment_close"
+            "name": "_verbatim_modifier_content"
           },
-          "named": false,
-          "value": "_close"
-        }
-      ]
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "inline_comment_close"
+            },
+            "named": false,
+            "value": "_close"
+          }
+        ]
+      }
     },
     "inline_math": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "inline_math_open"
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "inline_math_open"
+            },
+            "named": false,
+            "value": "_open"
           },
-          "named": false,
-          "value": "_open"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_verbatim_modifier_content"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
+          {
             "type": "SYMBOL",
-            "name": "inline_math_close"
+            "name": "_verbatim_modifier_content"
           },
-          "named": false,
-          "value": "_close"
-        }
-      ]
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "inline_math_close"
+            },
+            "named": false,
+            "value": "_close"
+          }
+        ]
+      }
     },
     "variable": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "variable_open"
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "variable_open"
+            },
+            "named": false,
+            "value": "_open"
           },
-          "named": false,
-          "value": "_open"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_verbatim_modifier_content"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
+          {
             "type": "SYMBOL",
-            "name": "variable_close"
+            "name": "_verbatim_modifier_content"
           },
-          "named": false,
-          "value": "_close"
-        }
-      ]
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "variable_close"
+            },
+            "named": false,
+            "value": "_close"
+          }
+        ]
+      }
     },
     "_conflict_open": {
       "type": "PREC_DYNAMIC",
@@ -1289,18 +1337,9 @@
         ]
       }
     },
-    "ranged_bold": {
+    "_ranged_bold": {
       "type": "SEQ",
       "members": [
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "ranged_modifier_open"
-          },
-          "named": false,
-          "value": "_open"
-        },
         {
           "type": "ALIAS",
           "content": {
@@ -1322,30 +1361,12 @@
           },
           "named": false,
           "value": "_close"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "ranged_modifier_close"
-          },
-          "named": false,
-          "value": "_close"
         }
       ]
     },
-    "ranged_italic": {
+    "_ranged_italic": {
       "type": "SEQ",
       "members": [
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "ranged_modifier_open"
-          },
-          "named": false,
-          "value": "_open"
-        },
         {
           "type": "ALIAS",
           "content": {
@@ -1367,30 +1388,12 @@
           },
           "named": false,
           "value": "_close"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "ranged_modifier_close"
-          },
-          "named": false,
-          "value": "_close"
         }
       ]
     },
-    "ranged_strikethrough": {
+    "_ranged_strikethrough": {
       "type": "SEQ",
       "members": [
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "ranged_modifier_open"
-          },
-          "named": false,
-          "value": "_open"
-        },
         {
           "type": "ALIAS",
           "content": {
@@ -1412,30 +1415,12 @@
           },
           "named": false,
           "value": "_close"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "ranged_modifier_close"
-          },
-          "named": false,
-          "value": "_close"
         }
       ]
     },
-    "ranged_underline": {
+    "_ranged_underline": {
       "type": "SEQ",
       "members": [
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "ranged_modifier_open"
-          },
-          "named": false,
-          "value": "_open"
-        },
         {
           "type": "ALIAS",
           "content": {
@@ -1457,30 +1442,12 @@
           },
           "named": false,
           "value": "_close"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "ranged_modifier_close"
-          },
-          "named": false,
-          "value": "_close"
         }
       ]
     },
-    "ranged_spoiler": {
+    "_ranged_spoiler": {
       "type": "SEQ",
       "members": [
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "ranged_modifier_open"
-          },
-          "named": false,
-          "value": "_open"
-        },
         {
           "type": "ALIAS",
           "content": {
@@ -1502,30 +1469,12 @@
           },
           "named": false,
           "value": "_close"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "ranged_modifier_close"
-          },
-          "named": false,
-          "value": "_close"
         }
       ]
     },
-    "ranged_superscript": {
+    "_ranged_superscript": {
       "type": "SEQ",
       "members": [
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "ranged_modifier_open"
-          },
-          "named": false,
-          "value": "_open"
-        },
         {
           "type": "ALIAS",
           "content": {
@@ -1547,30 +1496,12 @@
           },
           "named": false,
           "value": "_close"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "ranged_modifier_close"
-          },
-          "named": false,
-          "value": "_close"
         }
       ]
     },
-    "ranged_subscript": {
+    "_ranged_subscript": {
       "type": "SEQ",
       "members": [
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "ranged_modifier_open"
-          },
-          "named": false,
-          "value": "_open"
-        },
         {
           "type": "ALIAS",
           "content": {
@@ -1592,30 +1523,12 @@
           },
           "named": false,
           "value": "_close"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "ranged_modifier_close"
-          },
-          "named": false,
-          "value": "_close"
         }
       ]
     },
-    "ranged_verbatim": {
+    "_ranged_verbatim": {
       "type": "SEQ",
       "members": [
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "ranged_modifier_open"
-          },
-          "named": false,
-          "value": "_open"
-        },
         {
           "type": "ALIAS",
           "content": {
@@ -1627,7 +1540,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_ranged_verbatim_attached_modifier_content"
+          "name": "_ranged_verbatim_modifier_content"
         },
         {
           "type": "ALIAS",
@@ -1637,30 +1550,12 @@
           },
           "named": false,
           "value": "_close"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "ranged_modifier_close"
-          },
-          "named": false,
-          "value": "_close"
         }
       ]
     },
-    "ranged_inline_comment": {
+    "_ranged_inline_comment": {
       "type": "SEQ",
       "members": [
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "ranged_modifier_open"
-          },
-          "named": false,
-          "value": "_open"
-        },
         {
           "type": "ALIAS",
           "content": {
@@ -1672,7 +1567,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_ranged_verbatim_attached_modifier_content"
+          "name": "_ranged_verbatim_modifier_content"
         },
         {
           "type": "ALIAS",
@@ -1682,30 +1577,12 @@
           },
           "named": false,
           "value": "_close"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "ranged_modifier_close"
-          },
-          "named": false,
-          "value": "_close"
         }
       ]
     },
-    "ranged_inline_math": {
+    "_ranged_inline_math": {
       "type": "SEQ",
       "members": [
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "ranged_modifier_open"
-          },
-          "named": false,
-          "value": "_open"
-        },
         {
           "type": "ALIAS",
           "content": {
@@ -1717,7 +1594,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_ranged_verbatim_attached_modifier_content"
+          "name": "_ranged_verbatim_modifier_content"
         },
         {
           "type": "ALIAS",
@@ -1727,30 +1604,12 @@
           },
           "named": false,
           "value": "_close"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "ranged_modifier_close"
-          },
-          "named": false,
-          "value": "_close"
         }
       ]
     },
-    "ranged_variable": {
+    "_ranged_variable": {
       "type": "SEQ",
       "members": [
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "ranged_modifier_open"
-          },
-          "named": false,
-          "value": "_open"
-        },
         {
           "type": "ALIAS",
           "content": {
@@ -1762,22 +1621,13 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_ranged_verbatim_attached_modifier_content"
+          "name": "_ranged_verbatim_modifier_content"
         },
         {
           "type": "ALIAS",
           "content": {
             "type": "SYMBOL",
             "name": "variable_close"
-          },
-          "named": false,
-          "value": "_close"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "ranged_modifier_close"
           },
           "named": false,
           "value": "_close"
@@ -5455,52 +5305,134 @@
         }
       ]
     },
-    "ranged_attached_modifier": {
+    "_ranged_attached_modifier": {
       "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "ranged_bold"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_ranged_bold"
+          },
+          "named": true,
+          "value": "bold"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_ranged_italic"
+          },
+          "named": true,
+          "value": "italic"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_ranged_strikethrough"
+          },
+          "named": true,
+          "value": "strikethrough"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_ranged_underline"
+          },
+          "named": true,
+          "value": "underline"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_ranged_spoiler"
+          },
+          "named": true,
+          "value": "spoiler"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_ranged_superscript"
+          },
+          "named": true,
+          "value": "superscript"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_ranged_subscript"
+          },
+          "named": true,
+          "value": "subscript"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_ranged_verbatim"
+          },
+          "named": true,
+          "value": "verbatim"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_ranged_inline_comment"
+          },
+          "named": true,
+          "value": "inline_comment"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_ranged_inline_math"
+          },
+          "named": true,
+          "value": "inline_math"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_ranged_variable"
+          },
+          "named": true,
+          "value": "variable"
+        }
+      ]
+    },
+    "ranged_attached_modifier": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "ranged_modifier_open"
+          },
+          "named": false,
+          "value": "_open"
         },
         {
           "type": "SYMBOL",
-          "name": "ranged_italic"
+          "name": "_ranged_attached_modifier"
         },
         {
-          "type": "SYMBOL",
-          "name": "ranged_strikethrough"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "ranged_underline"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "ranged_spoiler"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "ranged_superscript"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "ranged_subscript"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "ranged_verbatim"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "ranged_inline_comment"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "ranged_inline_math"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "ranged_variable"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "ranged_modifier_close"
+          },
+          "named": false,
+          "value": "_close"
         }
       ]
     }
@@ -5555,6 +5487,58 @@
     [
       "variable",
       "_conflict_open"
+    ],
+    [
+      "_ranged_bold",
+      "_conflict_open"
+    ],
+    [
+      "_ranged_italic",
+      "_conflict_open"
+    ],
+    [
+      "_ranged_strikethrough",
+      "_conflict_open"
+    ],
+    [
+      "_ranged_underline",
+      "_conflict_open"
+    ],
+    [
+      "_ranged_spoiler",
+      "_conflict_open"
+    ],
+    [
+      "_ranged_verbatim",
+      "_conflict_open"
+    ],
+    [
+      "_ranged_superscript",
+      "_conflict_open"
+    ],
+    [
+      "_ranged_subscript",
+      "_conflict_open"
+    ],
+    [
+      "_ranged_inline_comment",
+      "_conflict_open"
+    ],
+    [
+      "_ranged_inline_math",
+      "_conflict_open"
+    ],
+    [
+      "_ranged_variable",
+      "_conflict_open"
+    ],
+    [
+      "_attached_modifier_content",
+      "_ranged_attached_modifier_content"
+    ],
+    [
+      "_verbatim_modifier_content",
+      "_ranged_verbatim_modifier_content"
     ],
     [
       "bold",
@@ -6099,7 +6083,6 @@
   "inline": [],
   "supertypes": [
     "attached_modifier",
-    "ranged_attached_modifier",
     "heading",
     "detached_modifier",
     "footnote",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -190,17 +190,7 @@
     ]
   },
   {
-    "type": "_close",
-    "named": false,
-    "fields": {}
-  },
-  {
     "type": "_lowercase",
-    "named": false,
-    "fields": {}
-  },
-  {
-    "type": "_open",
     "named": false,
     "fields": {}
   },
@@ -2721,6 +2711,10 @@
         {
           "type": "link_modifier",
           "named": true
+        },
+        {
+          "type": "ranged_attached_modifier",
+          "named": true
         }
       ]
     }
@@ -2766,6 +2760,10 @@
         {
           "type": "link_modifier",
           "named": true
+        },
+        {
+          "type": "ranged_attached_modifier",
+          "named": true
         }
       ]
     }
@@ -2800,6 +2798,10 @@
         },
         {
           "type": "link_modifier",
+          "named": true
+        },
+        {
+          "type": "ranged_attached_modifier",
           "named": true
         }
       ]
@@ -2836,6 +2838,10 @@
         {
           "type": "link_modifier",
           "named": true
+        },
+        {
+          "type": "ranged_attached_modifier",
+          "named": true
         }
       ]
     }
@@ -2871,6 +2877,10 @@
         {
           "type": "link_modifier",
           "named": true
+        },
+        {
+          "type": "ranged_attached_modifier",
+          "named": true
         }
       ]
     }
@@ -2905,6 +2915,10 @@
         },
         {
           "type": "link_modifier",
+          "named": true
+        },
+        {
+          "type": "ranged_attached_modifier",
           "named": true
         }
       ]
@@ -3001,6 +3015,10 @@
         },
         {
           "type": "link_modifier",
+          "named": true
+        },
+        {
+          "type": "ranged_attached_modifier",
           "named": true
         }
       ]
@@ -4998,14 +5016,6 @@
     "named": false
   },
   {
-    "type": "_bold_close",
-    "named": false
-  },
-  {
-    "type": "_bold_open",
-    "named": false
-  },
-  {
     "type": "_close",
     "named": false
   },
@@ -5015,30 +5025,6 @@
   },
   {
     "type": "_end",
-    "named": false
-  },
-  {
-    "type": "_inline_comment_close",
-    "named": false
-  },
-  {
-    "type": "_inline_comment_open",
-    "named": false
-  },
-  {
-    "type": "_inline_math_close",
-    "named": false
-  },
-  {
-    "type": "_inline_math_open",
-    "named": false
-  },
-  {
-    "type": "_italic_close",
-    "named": false
-  },
-  {
-    "type": "_italic_open",
     "named": false
   },
   {
@@ -5058,10 +5044,6 @@
     "named": false
   },
   {
-    "type": "_ranged_modifier",
-    "named": false
-  },
-  {
     "type": "_segment",
     "named": false
   },
@@ -5070,39 +5052,7 @@
     "named": false
   },
   {
-    "type": "_spoiler_close",
-    "named": false
-  },
-  {
-    "type": "_spoiler_open",
-    "named": false
-  },
-  {
-    "type": "_strikethrough_close",
-    "named": false
-  },
-  {
-    "type": "_strikethrough_open",
-    "named": false
-  },
-  {
-    "type": "_subscript_close",
-    "named": false
-  },
-  {
-    "type": "_subscript_open",
-    "named": false
-  },
-  {
     "type": "_suffix",
-    "named": false
-  },
-  {
-    "type": "_superscript_close",
-    "named": false
-  },
-  {
-    "type": "_superscript_open",
     "named": false
   },
   {
@@ -5110,31 +5060,7 @@
     "named": false
   },
   {
-    "type": "_underline_close",
-    "named": false
-  },
-  {
-    "type": "_underline_open",
-    "named": false
-  },
-  {
     "type": "_uppercase",
-    "named": false
-  },
-  {
-    "type": "_variable_close",
-    "named": false
-  },
-  {
-    "type": "_variable_open",
-    "named": false
-  },
-  {
-    "type": "_verbatim_close",
-    "named": false
-  },
-  {
-    "type": "_verbatim_open",
     "named": false
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -126,6 +126,56 @@
     ]
   },
   {
+    "type": "ranged_attached_modifier",
+    "named": true,
+    "subtypes": [
+      {
+        "type": "ranged_bold",
+        "named": true
+      },
+      {
+        "type": "ranged_inline_comment",
+        "named": true
+      },
+      {
+        "type": "ranged_inline_math",
+        "named": true
+      },
+      {
+        "type": "ranged_italic",
+        "named": true
+      },
+      {
+        "type": "ranged_spoiler",
+        "named": true
+      },
+      {
+        "type": "ranged_strikethrough",
+        "named": true
+      },
+      {
+        "type": "ranged_subscript",
+        "named": true
+      },
+      {
+        "type": "ranged_superscript",
+        "named": true
+      },
+      {
+        "type": "ranged_underline",
+        "named": true
+      },
+      {
+        "type": "ranged_variable",
+        "named": true
+      },
+      {
+        "type": "ranged_verbatim",
+        "named": true
+      }
+    ]
+  },
+  {
     "type": "tag",
     "named": true,
     "subtypes": [
@@ -140,7 +190,17 @@
     ]
   },
   {
+    "type": "_close",
+    "named": false,
+    "fields": {}
+  },
+  {
     "type": "_lowercase",
+    "named": false,
+    "fields": {}
+  },
+  {
+    "type": "_open",
     "named": false,
     "fields": {}
   },
@@ -174,6 +234,10 @@
         },
         {
           "type": "link_modifier",
+          "named": true
+        },
+        {
+          "type": "ranged_attached_modifier",
           "named": true
         }
       ]
@@ -2367,6 +2431,10 @@
         {
           "type": "link_modifier",
           "named": true
+        },
+        {
+          "type": "ranged_attached_modifier",
+          "named": true
         }
       ]
     }
@@ -2623,6 +2691,226 @@
     }
   },
   {
+    "type": "ranged_bold",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "anchor_declaration",
+          "named": true
+        },
+        {
+          "type": "anchor_definition",
+          "named": true
+        },
+        {
+          "type": "attached_modifier",
+          "named": true
+        },
+        {
+          "type": "escape_sequence",
+          "named": true
+        },
+        {
+          "type": "link",
+          "named": true
+        },
+        {
+          "type": "link_modifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "ranged_inline_comment",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "ranged_inline_math",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "ranged_italic",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "anchor_declaration",
+          "named": true
+        },
+        {
+          "type": "anchor_definition",
+          "named": true
+        },
+        {
+          "type": "attached_modifier",
+          "named": true
+        },
+        {
+          "type": "escape_sequence",
+          "named": true
+        },
+        {
+          "type": "link",
+          "named": true
+        },
+        {
+          "type": "link_modifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "ranged_spoiler",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "anchor_declaration",
+          "named": true
+        },
+        {
+          "type": "anchor_definition",
+          "named": true
+        },
+        {
+          "type": "attached_modifier",
+          "named": true
+        },
+        {
+          "type": "escape_sequence",
+          "named": true
+        },
+        {
+          "type": "link",
+          "named": true
+        },
+        {
+          "type": "link_modifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "ranged_strikethrough",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "anchor_declaration",
+          "named": true
+        },
+        {
+          "type": "anchor_definition",
+          "named": true
+        },
+        {
+          "type": "attached_modifier",
+          "named": true
+        },
+        {
+          "type": "escape_sequence",
+          "named": true
+        },
+        {
+          "type": "link",
+          "named": true
+        },
+        {
+          "type": "link_modifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "ranged_subscript",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "anchor_declaration",
+          "named": true
+        },
+        {
+          "type": "anchor_definition",
+          "named": true
+        },
+        {
+          "type": "attached_modifier",
+          "named": true
+        },
+        {
+          "type": "escape_sequence",
+          "named": true
+        },
+        {
+          "type": "link",
+          "named": true
+        },
+        {
+          "type": "link_modifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "ranged_superscript",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "anchor_declaration",
+          "named": true
+        },
+        {
+          "type": "anchor_definition",
+          "named": true
+        },
+        {
+          "type": "attached_modifier",
+          "named": true
+        },
+        {
+          "type": "escape_sequence",
+          "named": true
+        },
+        {
+          "type": "link",
+          "named": true
+        },
+        {
+          "type": "link_modifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "ranged_tag",
     "named": true,
     "fields": {
@@ -2680,6 +2968,51 @@
   },
   {
     "type": "ranged_tag_end",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "ranged_underline",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "anchor_declaration",
+          "named": true
+        },
+        {
+          "type": "anchor_definition",
+          "named": true
+        },
+        {
+          "type": "attached_modifier",
+          "named": true
+        },
+        {
+          "type": "escape_sequence",
+          "named": true
+        },
+        {
+          "type": "link",
+          "named": true
+        },
+        {
+          "type": "link_modifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "ranged_variable",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "ranged_verbatim",
     "named": true,
     "fields": {}
   },
@@ -4665,6 +4998,14 @@
     "named": false
   },
   {
+    "type": "_bold_close",
+    "named": false
+  },
+  {
+    "type": "_bold_open",
+    "named": false
+  },
+  {
     "type": "_close",
     "named": false
   },
@@ -4674,6 +5015,30 @@
   },
   {
     "type": "_end",
+    "named": false
+  },
+  {
+    "type": "_inline_comment_close",
+    "named": false
+  },
+  {
+    "type": "_inline_comment_open",
+    "named": false
+  },
+  {
+    "type": "_inline_math_close",
+    "named": false
+  },
+  {
+    "type": "_inline_math_open",
+    "named": false
+  },
+  {
+    "type": "_italic_close",
+    "named": false
+  },
+  {
+    "type": "_italic_open",
     "named": false
   },
   {
@@ -4693,6 +5058,10 @@
     "named": false
   },
   {
+    "type": "_ranged_modifier",
+    "named": false
+  },
+  {
     "type": "_segment",
     "named": false
   },
@@ -4701,7 +5070,39 @@
     "named": false
   },
   {
+    "type": "_spoiler_close",
+    "named": false
+  },
+  {
+    "type": "_spoiler_open",
+    "named": false
+  },
+  {
+    "type": "_strikethrough_close",
+    "named": false
+  },
+  {
+    "type": "_strikethrough_open",
+    "named": false
+  },
+  {
+    "type": "_subscript_close",
+    "named": false
+  },
+  {
+    "type": "_subscript_open",
+    "named": false
+  },
+  {
     "type": "_suffix",
+    "named": false
+  },
+  {
+    "type": "_superscript_close",
+    "named": false
+  },
+  {
+    "type": "_superscript_open",
     "named": false
   },
   {
@@ -4709,7 +5110,31 @@
     "named": false
   },
   {
+    "type": "_underline_close",
+    "named": false
+  },
+  {
+    "type": "_underline_open",
+    "named": false
+  },
+  {
     "type": "_uppercase",
+    "named": false
+  },
+  {
+    "type": "_variable_close",
+    "named": false
+  },
+  {
+    "type": "_variable_open",
+    "named": false
+  },
+  {
+    "type": "_verbatim_close",
+    "named": false
+  },
+  {
+    "type": "_verbatim_open",
     "named": false
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1008,6 +1008,133 @@
     }
   },
   {
+    "type": "indent_segment",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "indent_modifier",
+          "named": true
+        },
+        {
+          "type": "ordered_link2",
+          "named": true
+        },
+        {
+          "type": "ordered_link3",
+          "named": true
+        },
+        {
+          "type": "ordered_link4",
+          "named": true
+        },
+        {
+          "type": "ordered_link5",
+          "named": true
+        },
+        {
+          "type": "ordered_link6",
+          "named": true
+        },
+        {
+          "type": "ordered_list2",
+          "named": true
+        },
+        {
+          "type": "ordered_list3",
+          "named": true
+        },
+        {
+          "type": "ordered_list4",
+          "named": true
+        },
+        {
+          "type": "ordered_list5",
+          "named": true
+        },
+        {
+          "type": "ordered_list6",
+          "named": true
+        },
+        {
+          "type": "paragraph",
+          "named": true
+        },
+        {
+          "type": "tag",
+          "named": true
+        },
+        {
+          "type": "todo_item2",
+          "named": true
+        },
+        {
+          "type": "todo_item3",
+          "named": true
+        },
+        {
+          "type": "todo_item4",
+          "named": true
+        },
+        {
+          "type": "todo_item5",
+          "named": true
+        },
+        {
+          "type": "todo_item6",
+          "named": true
+        },
+        {
+          "type": "unordered_link2",
+          "named": true
+        },
+        {
+          "type": "unordered_link3",
+          "named": true
+        },
+        {
+          "type": "unordered_link4",
+          "named": true
+        },
+        {
+          "type": "unordered_link5",
+          "named": true
+        },
+        {
+          "type": "unordered_link6",
+          "named": true
+        },
+        {
+          "type": "unordered_list2",
+          "named": true
+        },
+        {
+          "type": "unordered_list3",
+          "named": true
+        },
+        {
+          "type": "unordered_list4",
+          "named": true
+        },
+        {
+          "type": "unordered_list5",
+          "named": true
+        },
+        {
+          "type": "unordered_list6",
+          "named": true
+        },
+        {
+          "type": "weak_paragraph_delimiter",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "inline_comment",
     "named": true,
     "fields": {}
@@ -4550,6 +4677,10 @@
         "required": true,
         "types": [
           {
+            "type": "indent_segment",
+            "named": true
+          },
+          {
             "type": "paragraph",
             "named": true
           }
@@ -5101,6 +5232,10 @@
   },
   {
     "type": "horizontal_line",
+    "named": true
+  },
+  {
+    "type": "indent_modifier",
     "named": true
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -962,133 +962,6 @@
     }
   },
   {
-    "type": "indent_segment",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "indent_modifier",
-          "named": true
-        },
-        {
-          "type": "ordered_link2",
-          "named": true
-        },
-        {
-          "type": "ordered_link3",
-          "named": true
-        },
-        {
-          "type": "ordered_link4",
-          "named": true
-        },
-        {
-          "type": "ordered_link5",
-          "named": true
-        },
-        {
-          "type": "ordered_link6",
-          "named": true
-        },
-        {
-          "type": "ordered_list2",
-          "named": true
-        },
-        {
-          "type": "ordered_list3",
-          "named": true
-        },
-        {
-          "type": "ordered_list4",
-          "named": true
-        },
-        {
-          "type": "ordered_list5",
-          "named": true
-        },
-        {
-          "type": "ordered_list6",
-          "named": true
-        },
-        {
-          "type": "paragraph",
-          "named": true
-        },
-        {
-          "type": "tag",
-          "named": true
-        },
-        {
-          "type": "todo_item2",
-          "named": true
-        },
-        {
-          "type": "todo_item3",
-          "named": true
-        },
-        {
-          "type": "todo_item4",
-          "named": true
-        },
-        {
-          "type": "todo_item5",
-          "named": true
-        },
-        {
-          "type": "todo_item6",
-          "named": true
-        },
-        {
-          "type": "unordered_link2",
-          "named": true
-        },
-        {
-          "type": "unordered_link3",
-          "named": true
-        },
-        {
-          "type": "unordered_link4",
-          "named": true
-        },
-        {
-          "type": "unordered_link5",
-          "named": true
-        },
-        {
-          "type": "unordered_link6",
-          "named": true
-        },
-        {
-          "type": "unordered_list2",
-          "named": true
-        },
-        {
-          "type": "unordered_list3",
-          "named": true
-        },
-        {
-          "type": "unordered_list4",
-          "named": true
-        },
-        {
-          "type": "unordered_list5",
-          "named": true
-        },
-        {
-          "type": "unordered_list6",
-          "named": true
-        },
-        {
-          "type": "weak_paragraph_delimiter",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
     "type": "inline_comment",
     "named": true,
     "fields": {}
@@ -2009,11 +1882,143 @@
     "named": true,
     "fields": {
       "content": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
           {
+            "type": "indent_modifier",
+            "named": true
+          },
+          {
+            "type": "ordered_link2",
+            "named": true
+          },
+          {
+            "type": "ordered_link3",
+            "named": true
+          },
+          {
+            "type": "ordered_link4",
+            "named": true
+          },
+          {
+            "type": "ordered_link5",
+            "named": true
+          },
+          {
+            "type": "ordered_link6",
+            "named": true
+          },
+          {
+            "type": "ordered_list2",
+            "named": true
+          },
+          {
+            "type": "ordered_list3",
+            "named": true
+          },
+          {
+            "type": "ordered_list4",
+            "named": true
+          },
+          {
+            "type": "ordered_list5",
+            "named": true
+          },
+          {
+            "type": "ordered_list6",
+            "named": true
+          },
+          {
             "type": "paragraph",
+            "named": true
+          },
+          {
+            "type": "quote2",
+            "named": true
+          },
+          {
+            "type": "quote3",
+            "named": true
+          },
+          {
+            "type": "quote4",
+            "named": true
+          },
+          {
+            "type": "quote5",
+            "named": true
+          },
+          {
+            "type": "quote6",
+            "named": true
+          },
+          {
+            "type": "tag",
+            "named": true
+          },
+          {
+            "type": "todo_item2",
+            "named": true
+          },
+          {
+            "type": "todo_item3",
+            "named": true
+          },
+          {
+            "type": "todo_item4",
+            "named": true
+          },
+          {
+            "type": "todo_item5",
+            "named": true
+          },
+          {
+            "type": "todo_item6",
+            "named": true
+          },
+          {
+            "type": "unordered_link2",
+            "named": true
+          },
+          {
+            "type": "unordered_link3",
+            "named": true
+          },
+          {
+            "type": "unordered_link4",
+            "named": true
+          },
+          {
+            "type": "unordered_link5",
+            "named": true
+          },
+          {
+            "type": "unordered_link6",
+            "named": true
+          },
+          {
+            "type": "unordered_list2",
+            "named": true
+          },
+          {
+            "type": "unordered_list3",
+            "named": true
+          },
+          {
+            "type": "unordered_list4",
+            "named": true
+          },
+          {
+            "type": "unordered_list5",
+            "named": true
+          },
+          {
+            "type": "unordered_list6",
+            "named": true
+          },
+          {
+            "type": "weak_paragraph_delimiter",
             "named": true
           }
         ]
@@ -2135,11 +2140,119 @@
     "named": true,
     "fields": {
       "content": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
           {
+            "type": "indent_modifier",
+            "named": true
+          },
+          {
+            "type": "ordered_link3",
+            "named": true
+          },
+          {
+            "type": "ordered_link4",
+            "named": true
+          },
+          {
+            "type": "ordered_link5",
+            "named": true
+          },
+          {
+            "type": "ordered_link6",
+            "named": true
+          },
+          {
+            "type": "ordered_list3",
+            "named": true
+          },
+          {
+            "type": "ordered_list4",
+            "named": true
+          },
+          {
+            "type": "ordered_list5",
+            "named": true
+          },
+          {
+            "type": "ordered_list6",
+            "named": true
+          },
+          {
             "type": "paragraph",
+            "named": true
+          },
+          {
+            "type": "quote3",
+            "named": true
+          },
+          {
+            "type": "quote4",
+            "named": true
+          },
+          {
+            "type": "quote5",
+            "named": true
+          },
+          {
+            "type": "quote6",
+            "named": true
+          },
+          {
+            "type": "tag",
+            "named": true
+          },
+          {
+            "type": "todo_item3",
+            "named": true
+          },
+          {
+            "type": "todo_item4",
+            "named": true
+          },
+          {
+            "type": "todo_item5",
+            "named": true
+          },
+          {
+            "type": "todo_item6",
+            "named": true
+          },
+          {
+            "type": "unordered_link3",
+            "named": true
+          },
+          {
+            "type": "unordered_link4",
+            "named": true
+          },
+          {
+            "type": "unordered_link5",
+            "named": true
+          },
+          {
+            "type": "unordered_link6",
+            "named": true
+          },
+          {
+            "type": "unordered_list3",
+            "named": true
+          },
+          {
+            "type": "unordered_list4",
+            "named": true
+          },
+          {
+            "type": "unordered_list5",
+            "named": true
+          },
+          {
+            "type": "unordered_list6",
+            "named": true
+          },
+          {
+            "type": "weak_paragraph_delimiter",
             "named": true
           }
         ]
@@ -2241,11 +2354,95 @@
     "named": true,
     "fields": {
       "content": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
           {
+            "type": "indent_modifier",
+            "named": true
+          },
+          {
+            "type": "ordered_link4",
+            "named": true
+          },
+          {
+            "type": "ordered_link5",
+            "named": true
+          },
+          {
+            "type": "ordered_link6",
+            "named": true
+          },
+          {
+            "type": "ordered_list4",
+            "named": true
+          },
+          {
+            "type": "ordered_list5",
+            "named": true
+          },
+          {
+            "type": "ordered_list6",
+            "named": true
+          },
+          {
             "type": "paragraph",
+            "named": true
+          },
+          {
+            "type": "quote4",
+            "named": true
+          },
+          {
+            "type": "quote5",
+            "named": true
+          },
+          {
+            "type": "quote6",
+            "named": true
+          },
+          {
+            "type": "tag",
+            "named": true
+          },
+          {
+            "type": "todo_item4",
+            "named": true
+          },
+          {
+            "type": "todo_item5",
+            "named": true
+          },
+          {
+            "type": "todo_item6",
+            "named": true
+          },
+          {
+            "type": "unordered_link4",
+            "named": true
+          },
+          {
+            "type": "unordered_link5",
+            "named": true
+          },
+          {
+            "type": "unordered_link6",
+            "named": true
+          },
+          {
+            "type": "unordered_list4",
+            "named": true
+          },
+          {
+            "type": "unordered_list5",
+            "named": true
+          },
+          {
+            "type": "unordered_list6",
+            "named": true
+          },
+          {
+            "type": "weak_paragraph_delimiter",
             "named": true
           }
         ]
@@ -2327,11 +2524,71 @@
     "named": true,
     "fields": {
       "content": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
           {
+            "type": "indent_modifier",
+            "named": true
+          },
+          {
+            "type": "ordered_link5",
+            "named": true
+          },
+          {
+            "type": "ordered_link6",
+            "named": true
+          },
+          {
+            "type": "ordered_list5",
+            "named": true
+          },
+          {
+            "type": "ordered_list6",
+            "named": true
+          },
+          {
             "type": "paragraph",
+            "named": true
+          },
+          {
+            "type": "quote5",
+            "named": true
+          },
+          {
+            "type": "quote6",
+            "named": true
+          },
+          {
+            "type": "tag",
+            "named": true
+          },
+          {
+            "type": "todo_item5",
+            "named": true
+          },
+          {
+            "type": "todo_item6",
+            "named": true
+          },
+          {
+            "type": "unordered_link5",
+            "named": true
+          },
+          {
+            "type": "unordered_link6",
+            "named": true
+          },
+          {
+            "type": "unordered_list5",
+            "named": true
+          },
+          {
+            "type": "unordered_list6",
+            "named": true
+          },
+          {
+            "type": "weak_paragraph_delimiter",
             "named": true
           }
         ]
@@ -2393,11 +2650,47 @@
     "named": true,
     "fields": {
       "content": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
           {
+            "type": "indent_modifier",
+            "named": true
+          },
+          {
+            "type": "ordered_link6",
+            "named": true
+          },
+          {
+            "type": "ordered_list6",
+            "named": true
+          },
+          {
             "type": "paragraph",
+            "named": true
+          },
+          {
+            "type": "quote6",
+            "named": true
+          },
+          {
+            "type": "tag",
+            "named": true
+          },
+          {
+            "type": "todo_item6",
+            "named": true
+          },
+          {
+            "type": "unordered_link6",
+            "named": true
+          },
+          {
+            "type": "unordered_list6",
+            "named": true
+          },
+          {
+            "type": "weak_paragraph_delimiter",
             "named": true
           }
         ]
@@ -2439,11 +2732,23 @@
     "named": true,
     "fields": {
       "content": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
           {
+            "type": "indent_modifier",
+            "named": true
+          },
+          {
             "type": "paragraph",
+            "named": true
+          },
+          {
+            "type": "tag",
+            "named": true
+          },
+          {
+            "type": "weak_paragraph_delimiter",
             "named": true
           }
         ]
@@ -2554,11 +2859,143 @@
     "named": true,
     "fields": {
       "content": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
           {
+            "type": "indent_modifier",
+            "named": true
+          },
+          {
+            "type": "ordered_link2",
+            "named": true
+          },
+          {
+            "type": "ordered_link3",
+            "named": true
+          },
+          {
+            "type": "ordered_link4",
+            "named": true
+          },
+          {
+            "type": "ordered_link5",
+            "named": true
+          },
+          {
+            "type": "ordered_link6",
+            "named": true
+          },
+          {
+            "type": "ordered_list2",
+            "named": true
+          },
+          {
+            "type": "ordered_list3",
+            "named": true
+          },
+          {
+            "type": "ordered_list4",
+            "named": true
+          },
+          {
+            "type": "ordered_list5",
+            "named": true
+          },
+          {
+            "type": "ordered_list6",
+            "named": true
+          },
+          {
             "type": "paragraph",
+            "named": true
+          },
+          {
+            "type": "quote2",
+            "named": true
+          },
+          {
+            "type": "quote3",
+            "named": true
+          },
+          {
+            "type": "quote4",
+            "named": true
+          },
+          {
+            "type": "quote5",
+            "named": true
+          },
+          {
+            "type": "quote6",
+            "named": true
+          },
+          {
+            "type": "tag",
+            "named": true
+          },
+          {
+            "type": "todo_item2",
+            "named": true
+          },
+          {
+            "type": "todo_item3",
+            "named": true
+          },
+          {
+            "type": "todo_item4",
+            "named": true
+          },
+          {
+            "type": "todo_item5",
+            "named": true
+          },
+          {
+            "type": "todo_item6",
+            "named": true
+          },
+          {
+            "type": "unordered_link2",
+            "named": true
+          },
+          {
+            "type": "unordered_link3",
+            "named": true
+          },
+          {
+            "type": "unordered_link4",
+            "named": true
+          },
+          {
+            "type": "unordered_link5",
+            "named": true
+          },
+          {
+            "type": "unordered_link6",
+            "named": true
+          },
+          {
+            "type": "unordered_list2",
+            "named": true
+          },
+          {
+            "type": "unordered_list3",
+            "named": true
+          },
+          {
+            "type": "unordered_list4",
+            "named": true
+          },
+          {
+            "type": "unordered_list5",
+            "named": true
+          },
+          {
+            "type": "unordered_list6",
+            "named": true
+          },
+          {
+            "type": "weak_paragraph_delimiter",
             "named": true
           }
         ]
@@ -2600,11 +3037,119 @@
     "named": true,
     "fields": {
       "content": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
           {
+            "type": "indent_modifier",
+            "named": true
+          },
+          {
+            "type": "ordered_link3",
+            "named": true
+          },
+          {
+            "type": "ordered_link4",
+            "named": true
+          },
+          {
+            "type": "ordered_link5",
+            "named": true
+          },
+          {
+            "type": "ordered_link6",
+            "named": true
+          },
+          {
+            "type": "ordered_list3",
+            "named": true
+          },
+          {
+            "type": "ordered_list4",
+            "named": true
+          },
+          {
+            "type": "ordered_list5",
+            "named": true
+          },
+          {
+            "type": "ordered_list6",
+            "named": true
+          },
+          {
             "type": "paragraph",
+            "named": true
+          },
+          {
+            "type": "quote3",
+            "named": true
+          },
+          {
+            "type": "quote4",
+            "named": true
+          },
+          {
+            "type": "quote5",
+            "named": true
+          },
+          {
+            "type": "quote6",
+            "named": true
+          },
+          {
+            "type": "tag",
+            "named": true
+          },
+          {
+            "type": "todo_item3",
+            "named": true
+          },
+          {
+            "type": "todo_item4",
+            "named": true
+          },
+          {
+            "type": "todo_item5",
+            "named": true
+          },
+          {
+            "type": "todo_item6",
+            "named": true
+          },
+          {
+            "type": "unordered_link3",
+            "named": true
+          },
+          {
+            "type": "unordered_link4",
+            "named": true
+          },
+          {
+            "type": "unordered_link5",
+            "named": true
+          },
+          {
+            "type": "unordered_link6",
+            "named": true
+          },
+          {
+            "type": "unordered_list3",
+            "named": true
+          },
+          {
+            "type": "unordered_list4",
+            "named": true
+          },
+          {
+            "type": "unordered_list5",
+            "named": true
+          },
+          {
+            "type": "unordered_list6",
+            "named": true
+          },
+          {
+            "type": "weak_paragraph_delimiter",
             "named": true
           }
         ]
@@ -2642,11 +3187,95 @@
     "named": true,
     "fields": {
       "content": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
           {
+            "type": "indent_modifier",
+            "named": true
+          },
+          {
+            "type": "ordered_link4",
+            "named": true
+          },
+          {
+            "type": "ordered_link5",
+            "named": true
+          },
+          {
+            "type": "ordered_link6",
+            "named": true
+          },
+          {
+            "type": "ordered_list4",
+            "named": true
+          },
+          {
+            "type": "ordered_list5",
+            "named": true
+          },
+          {
+            "type": "ordered_list6",
+            "named": true
+          },
+          {
             "type": "paragraph",
+            "named": true
+          },
+          {
+            "type": "quote4",
+            "named": true
+          },
+          {
+            "type": "quote5",
+            "named": true
+          },
+          {
+            "type": "quote6",
+            "named": true
+          },
+          {
+            "type": "tag",
+            "named": true
+          },
+          {
+            "type": "todo_item4",
+            "named": true
+          },
+          {
+            "type": "todo_item5",
+            "named": true
+          },
+          {
+            "type": "todo_item6",
+            "named": true
+          },
+          {
+            "type": "unordered_link4",
+            "named": true
+          },
+          {
+            "type": "unordered_link5",
+            "named": true
+          },
+          {
+            "type": "unordered_link6",
+            "named": true
+          },
+          {
+            "type": "unordered_list4",
+            "named": true
+          },
+          {
+            "type": "unordered_list5",
+            "named": true
+          },
+          {
+            "type": "unordered_list6",
+            "named": true
+          },
+          {
+            "type": "weak_paragraph_delimiter",
             "named": true
           }
         ]
@@ -2680,11 +3309,71 @@
     "named": true,
     "fields": {
       "content": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
           {
+            "type": "indent_modifier",
+            "named": true
+          },
+          {
+            "type": "ordered_link5",
+            "named": true
+          },
+          {
+            "type": "ordered_link6",
+            "named": true
+          },
+          {
+            "type": "ordered_list5",
+            "named": true
+          },
+          {
+            "type": "ordered_list6",
+            "named": true
+          },
+          {
             "type": "paragraph",
+            "named": true
+          },
+          {
+            "type": "quote5",
+            "named": true
+          },
+          {
+            "type": "quote6",
+            "named": true
+          },
+          {
+            "type": "tag",
+            "named": true
+          },
+          {
+            "type": "todo_item5",
+            "named": true
+          },
+          {
+            "type": "todo_item6",
+            "named": true
+          },
+          {
+            "type": "unordered_link5",
+            "named": true
+          },
+          {
+            "type": "unordered_link6",
+            "named": true
+          },
+          {
+            "type": "unordered_list5",
+            "named": true
+          },
+          {
+            "type": "unordered_list6",
+            "named": true
+          },
+          {
+            "type": "weak_paragraph_delimiter",
             "named": true
           }
         ]
@@ -2714,11 +3403,47 @@
     "named": true,
     "fields": {
       "content": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
           {
+            "type": "indent_modifier",
+            "named": true
+          },
+          {
+            "type": "ordered_link6",
+            "named": true
+          },
+          {
+            "type": "ordered_list6",
+            "named": true
+          },
+          {
             "type": "paragraph",
+            "named": true
+          },
+          {
+            "type": "quote6",
+            "named": true
+          },
+          {
+            "type": "tag",
+            "named": true
+          },
+          {
+            "type": "todo_item6",
+            "named": true
+          },
+          {
+            "type": "unordered_link6",
+            "named": true
+          },
+          {
+            "type": "unordered_list6",
+            "named": true
+          },
+          {
+            "type": "weak_paragraph_delimiter",
             "named": true
           }
         ]
@@ -2744,11 +3469,23 @@
     "named": true,
     "fields": {
       "content": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
           {
+            "type": "indent_modifier",
+            "named": true
+          },
+          {
             "type": "paragraph",
+            "named": true
+          },
+          {
+            "type": "tag",
+            "named": true
+          },
+          {
+            "type": "weak_paragraph_delimiter",
             "named": true
           }
         ]
@@ -4413,15 +5150,143 @@
     "named": true,
     "fields": {
       "content": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
           {
-            "type": "indent_segment",
+            "type": "indent_modifier",
+            "named": true
+          },
+          {
+            "type": "ordered_link2",
+            "named": true
+          },
+          {
+            "type": "ordered_link3",
+            "named": true
+          },
+          {
+            "type": "ordered_link4",
+            "named": true
+          },
+          {
+            "type": "ordered_link5",
+            "named": true
+          },
+          {
+            "type": "ordered_link6",
+            "named": true
+          },
+          {
+            "type": "ordered_list2",
+            "named": true
+          },
+          {
+            "type": "ordered_list3",
+            "named": true
+          },
+          {
+            "type": "ordered_list4",
+            "named": true
+          },
+          {
+            "type": "ordered_list5",
+            "named": true
+          },
+          {
+            "type": "ordered_list6",
             "named": true
           },
           {
             "type": "paragraph",
+            "named": true
+          },
+          {
+            "type": "quote2",
+            "named": true
+          },
+          {
+            "type": "quote3",
+            "named": true
+          },
+          {
+            "type": "quote4",
+            "named": true
+          },
+          {
+            "type": "quote5",
+            "named": true
+          },
+          {
+            "type": "quote6",
+            "named": true
+          },
+          {
+            "type": "tag",
+            "named": true
+          },
+          {
+            "type": "todo_item2",
+            "named": true
+          },
+          {
+            "type": "todo_item3",
+            "named": true
+          },
+          {
+            "type": "todo_item4",
+            "named": true
+          },
+          {
+            "type": "todo_item5",
+            "named": true
+          },
+          {
+            "type": "todo_item6",
+            "named": true
+          },
+          {
+            "type": "unordered_link2",
+            "named": true
+          },
+          {
+            "type": "unordered_link3",
+            "named": true
+          },
+          {
+            "type": "unordered_link4",
+            "named": true
+          },
+          {
+            "type": "unordered_link5",
+            "named": true
+          },
+          {
+            "type": "unordered_link6",
+            "named": true
+          },
+          {
+            "type": "unordered_list2",
+            "named": true
+          },
+          {
+            "type": "unordered_list3",
+            "named": true
+          },
+          {
+            "type": "unordered_list4",
+            "named": true
+          },
+          {
+            "type": "unordered_list5",
+            "named": true
+          },
+          {
+            "type": "unordered_list6",
+            "named": true
+          },
+          {
+            "type": "weak_paragraph_delimiter",
             "named": true
           }
         ]
@@ -4543,11 +5408,119 @@
     "named": true,
     "fields": {
       "content": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
           {
+            "type": "indent_modifier",
+            "named": true
+          },
+          {
+            "type": "ordered_link3",
+            "named": true
+          },
+          {
+            "type": "ordered_link4",
+            "named": true
+          },
+          {
+            "type": "ordered_link5",
+            "named": true
+          },
+          {
+            "type": "ordered_link6",
+            "named": true
+          },
+          {
+            "type": "ordered_list3",
+            "named": true
+          },
+          {
+            "type": "ordered_list4",
+            "named": true
+          },
+          {
+            "type": "ordered_list5",
+            "named": true
+          },
+          {
+            "type": "ordered_list6",
+            "named": true
+          },
+          {
             "type": "paragraph",
+            "named": true
+          },
+          {
+            "type": "quote3",
+            "named": true
+          },
+          {
+            "type": "quote4",
+            "named": true
+          },
+          {
+            "type": "quote5",
+            "named": true
+          },
+          {
+            "type": "quote6",
+            "named": true
+          },
+          {
+            "type": "tag",
+            "named": true
+          },
+          {
+            "type": "todo_item3",
+            "named": true
+          },
+          {
+            "type": "todo_item4",
+            "named": true
+          },
+          {
+            "type": "todo_item5",
+            "named": true
+          },
+          {
+            "type": "todo_item6",
+            "named": true
+          },
+          {
+            "type": "unordered_link3",
+            "named": true
+          },
+          {
+            "type": "unordered_link4",
+            "named": true
+          },
+          {
+            "type": "unordered_link5",
+            "named": true
+          },
+          {
+            "type": "unordered_link6",
+            "named": true
+          },
+          {
+            "type": "unordered_list3",
+            "named": true
+          },
+          {
+            "type": "unordered_list4",
+            "named": true
+          },
+          {
+            "type": "unordered_list5",
+            "named": true
+          },
+          {
+            "type": "unordered_list6",
+            "named": true
+          },
+          {
+            "type": "weak_paragraph_delimiter",
             "named": true
           }
         ]
@@ -4649,11 +5622,95 @@
     "named": true,
     "fields": {
       "content": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
           {
+            "type": "indent_modifier",
+            "named": true
+          },
+          {
+            "type": "ordered_link4",
+            "named": true
+          },
+          {
+            "type": "ordered_link5",
+            "named": true
+          },
+          {
+            "type": "ordered_link6",
+            "named": true
+          },
+          {
+            "type": "ordered_list4",
+            "named": true
+          },
+          {
+            "type": "ordered_list5",
+            "named": true
+          },
+          {
+            "type": "ordered_list6",
+            "named": true
+          },
+          {
             "type": "paragraph",
+            "named": true
+          },
+          {
+            "type": "quote4",
+            "named": true
+          },
+          {
+            "type": "quote5",
+            "named": true
+          },
+          {
+            "type": "quote6",
+            "named": true
+          },
+          {
+            "type": "tag",
+            "named": true
+          },
+          {
+            "type": "todo_item4",
+            "named": true
+          },
+          {
+            "type": "todo_item5",
+            "named": true
+          },
+          {
+            "type": "todo_item6",
+            "named": true
+          },
+          {
+            "type": "unordered_link4",
+            "named": true
+          },
+          {
+            "type": "unordered_link5",
+            "named": true
+          },
+          {
+            "type": "unordered_link6",
+            "named": true
+          },
+          {
+            "type": "unordered_list4",
+            "named": true
+          },
+          {
+            "type": "unordered_list5",
+            "named": true
+          },
+          {
+            "type": "unordered_list6",
+            "named": true
+          },
+          {
+            "type": "weak_paragraph_delimiter",
             "named": true
           }
         ]
@@ -4735,11 +5792,71 @@
     "named": true,
     "fields": {
       "content": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
           {
+            "type": "indent_modifier",
+            "named": true
+          },
+          {
+            "type": "ordered_link5",
+            "named": true
+          },
+          {
+            "type": "ordered_link6",
+            "named": true
+          },
+          {
+            "type": "ordered_list5",
+            "named": true
+          },
+          {
+            "type": "ordered_list6",
+            "named": true
+          },
+          {
             "type": "paragraph",
+            "named": true
+          },
+          {
+            "type": "quote5",
+            "named": true
+          },
+          {
+            "type": "quote6",
+            "named": true
+          },
+          {
+            "type": "tag",
+            "named": true
+          },
+          {
+            "type": "todo_item5",
+            "named": true
+          },
+          {
+            "type": "todo_item6",
+            "named": true
+          },
+          {
+            "type": "unordered_link5",
+            "named": true
+          },
+          {
+            "type": "unordered_link6",
+            "named": true
+          },
+          {
+            "type": "unordered_list5",
+            "named": true
+          },
+          {
+            "type": "unordered_list6",
+            "named": true
+          },
+          {
+            "type": "weak_paragraph_delimiter",
             "named": true
           }
         ]
@@ -4801,11 +5918,47 @@
     "named": true,
     "fields": {
       "content": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
           {
+            "type": "indent_modifier",
+            "named": true
+          },
+          {
+            "type": "ordered_link6",
+            "named": true
+          },
+          {
+            "type": "ordered_list6",
+            "named": true
+          },
+          {
             "type": "paragraph",
+            "named": true
+          },
+          {
+            "type": "quote6",
+            "named": true
+          },
+          {
+            "type": "tag",
+            "named": true
+          },
+          {
+            "type": "todo_item6",
+            "named": true
+          },
+          {
+            "type": "unordered_link6",
+            "named": true
+          },
+          {
+            "type": "unordered_list6",
+            "named": true
+          },
+          {
+            "type": "weak_paragraph_delimiter",
             "named": true
           }
         ]
@@ -4847,11 +6000,23 @@
     "named": true,
     "fields": {
       "content": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
           {
+            "type": "indent_modifier",
+            "named": true
+          },
+          {
             "type": "paragraph",
+            "named": true
+          },
+          {
+            "type": "tag",
+            "named": true
+          },
+          {
+            "type": "weak_paragraph_delimiter",
             "named": true
           }
         ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2473,7 +2473,7 @@
         "required": true,
         "types": [
           {
-            "type": "paragraph_segment",
+            "type": "paragraph",
             "named": true
           }
         ]
@@ -2519,7 +2519,7 @@
         "required": true,
         "types": [
           {
-            "type": "paragraph_segment",
+            "type": "paragraph",
             "named": true
           }
         ]
@@ -2561,7 +2561,7 @@
         "required": true,
         "types": [
           {
-            "type": "paragraph_segment",
+            "type": "paragraph",
             "named": true
           }
         ]
@@ -2599,7 +2599,7 @@
         "required": true,
         "types": [
           {
-            "type": "paragraph_segment",
+            "type": "paragraph",
             "named": true
           }
         ]
@@ -2633,7 +2633,7 @@
         "required": true,
         "types": [
           {
-            "type": "paragraph_segment",
+            "type": "paragraph",
             "named": true
           }
         ]
@@ -2663,7 +2663,7 @@
         "required": true,
         "types": [
           {
-            "type": "paragraph_segment",
+            "type": "paragraph",
             "named": true
           }
         ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -126,56 +126,6 @@
     ]
   },
   {
-    "type": "ranged_attached_modifier",
-    "named": true,
-    "subtypes": [
-      {
-        "type": "ranged_bold",
-        "named": true
-      },
-      {
-        "type": "ranged_inline_comment",
-        "named": true
-      },
-      {
-        "type": "ranged_inline_math",
-        "named": true
-      },
-      {
-        "type": "ranged_italic",
-        "named": true
-      },
-      {
-        "type": "ranged_spoiler",
-        "named": true
-      },
-      {
-        "type": "ranged_strikethrough",
-        "named": true
-      },
-      {
-        "type": "ranged_subscript",
-        "named": true
-      },
-      {
-        "type": "ranged_superscript",
-        "named": true
-      },
-      {
-        "type": "ranged_underline",
-        "named": true
-      },
-      {
-        "type": "ranged_variable",
-        "named": true
-      },
-      {
-        "type": "ranged_verbatim",
-        "named": true
-      }
-    ]
-  },
-  {
     "type": "tag",
     "named": true,
     "subtypes": [
@@ -302,6 +252,10 @@
         },
         {
           "type": "link_modifier",
+          "named": true
+        },
+        {
+          "type": "ranged_attached_modifier",
           "named": true
         }
       ]
@@ -1214,6 +1168,10 @@
         },
         {
           "type": "link_modifier",
+          "named": true
+        },
+        {
+          "type": "ranged_attached_modifier",
           "named": true
         }
       ]
@@ -2808,244 +2766,55 @@
     }
   },
   {
-    "type": "ranged_bold",
+    "type": "ranged_attached_modifier",
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
-      "required": false,
+      "multiple": false,
+      "required": true,
       "types": [
         {
-          "type": "anchor_declaration",
+          "type": "bold",
           "named": true
         },
         {
-          "type": "anchor_definition",
+          "type": "inline_comment",
           "named": true
         },
         {
-          "type": "attached_modifier",
+          "type": "inline_math",
           "named": true
         },
         {
-          "type": "escape_sequence",
+          "type": "italic",
           "named": true
         },
         {
-          "type": "link",
+          "type": "spoiler",
           "named": true
         },
         {
-          "type": "link_modifier",
+          "type": "strikethrough",
           "named": true
         },
         {
-          "type": "ranged_attached_modifier",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "ranged_inline_comment",
-    "named": true,
-    "fields": {}
-  },
-  {
-    "type": "ranged_inline_math",
-    "named": true,
-    "fields": {}
-  },
-  {
-    "type": "ranged_italic",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "anchor_declaration",
+          "type": "subscript",
           "named": true
         },
         {
-          "type": "anchor_definition",
+          "type": "superscript",
           "named": true
         },
         {
-          "type": "attached_modifier",
+          "type": "underline",
           "named": true
         },
         {
-          "type": "escape_sequence",
+          "type": "variable",
           "named": true
         },
         {
-          "type": "link",
-          "named": true
-        },
-        {
-          "type": "link_modifier",
-          "named": true
-        },
-        {
-          "type": "ranged_attached_modifier",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "ranged_spoiler",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "anchor_declaration",
-          "named": true
-        },
-        {
-          "type": "anchor_definition",
-          "named": true
-        },
-        {
-          "type": "attached_modifier",
-          "named": true
-        },
-        {
-          "type": "escape_sequence",
-          "named": true
-        },
-        {
-          "type": "link",
-          "named": true
-        },
-        {
-          "type": "link_modifier",
-          "named": true
-        },
-        {
-          "type": "ranged_attached_modifier",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "ranged_strikethrough",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "anchor_declaration",
-          "named": true
-        },
-        {
-          "type": "anchor_definition",
-          "named": true
-        },
-        {
-          "type": "attached_modifier",
-          "named": true
-        },
-        {
-          "type": "escape_sequence",
-          "named": true
-        },
-        {
-          "type": "link",
-          "named": true
-        },
-        {
-          "type": "link_modifier",
-          "named": true
-        },
-        {
-          "type": "ranged_attached_modifier",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "ranged_subscript",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "anchor_declaration",
-          "named": true
-        },
-        {
-          "type": "anchor_definition",
-          "named": true
-        },
-        {
-          "type": "attached_modifier",
-          "named": true
-        },
-        {
-          "type": "escape_sequence",
-          "named": true
-        },
-        {
-          "type": "link",
-          "named": true
-        },
-        {
-          "type": "link_modifier",
-          "named": true
-        },
-        {
-          "type": "ranged_attached_modifier",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "ranged_superscript",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "anchor_declaration",
-          "named": true
-        },
-        {
-          "type": "anchor_definition",
-          "named": true
-        },
-        {
-          "type": "attached_modifier",
-          "named": true
-        },
-        {
-          "type": "escape_sequence",
-          "named": true
-        },
-        {
-          "type": "link",
-          "named": true
-        },
-        {
-          "type": "link_modifier",
-          "named": true
-        },
-        {
-          "type": "ranged_attached_modifier",
+          "type": "verbatim",
           "named": true
         }
       ]
@@ -3109,55 +2878,6 @@
   },
   {
     "type": "ranged_tag_end",
-    "named": true,
-    "fields": {}
-  },
-  {
-    "type": "ranged_underline",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "anchor_declaration",
-          "named": true
-        },
-        {
-          "type": "anchor_definition",
-          "named": true
-        },
-        {
-          "type": "attached_modifier",
-          "named": true
-        },
-        {
-          "type": "escape_sequence",
-          "named": true
-        },
-        {
-          "type": "link",
-          "named": true
-        },
-        {
-          "type": "link_modifier",
-          "named": true
-        },
-        {
-          "type": "ranged_attached_modifier",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "ranged_variable",
-    "named": true,
-    "fields": {}
-  },
-  {
-    "type": "ranged_verbatim",
     "named": true,
     "fields": {}
   },
@@ -3264,6 +2984,10 @@
         {
           "type": "link_modifier",
           "named": true
+        },
+        {
+          "type": "ranged_attached_modifier",
+          "named": true
         }
       ]
     }
@@ -3298,6 +3022,10 @@
         },
         {
           "type": "link_modifier",
+          "named": true
+        },
+        {
+          "type": "ranged_attached_modifier",
           "named": true
         }
       ]
@@ -3334,6 +3062,10 @@
         {
           "type": "link_modifier",
           "named": true
+        },
+        {
+          "type": "ranged_attached_modifier",
+          "named": true
         }
       ]
     }
@@ -3368,6 +3100,10 @@
         },
         {
           "type": "link_modifier",
+          "named": true
+        },
+        {
+          "type": "ranged_attached_modifier",
           "named": true
         }
       ]
@@ -4123,6 +3859,10 @@
         },
         {
           "type": "link_modifier",
+          "named": true
+        },
+        {
+          "type": "ranged_attached_modifier",
           "named": true
         }
       ]

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -783,12 +783,20 @@ class Scanner
                 return NONE;
             }
 
-            /* TODO: what is this?
             auto can_have_modifier = [&]()
             {
-                return !m_ActiveModifiers[(VERBATIM_OPEN - BOLD_OPEN) / 2];
+
+                return (
+                    !m_ActiveModifiers[(VERBATIM_OPEN - BOLD_OPEN) / 2] &&
+                    !m_ActiveModifiers[(INLINE_COMMENT_OPEN - BOLD_OPEN) / 2] &&
+                    !m_ActiveModifiers[(INLINE_MATH_OPEN - BOLD_OPEN) / 2] &&
+                    !m_ActiveModifiers[(VARIABLE_OPEN - BOLD_OPEN) / 2] &&
+                    !m_RangedActiveModifiers[(VERBATIM_OPEN - BOLD_OPEN) / 2] &&
+                    !m_RangedActiveModifiers[(INLINE_COMMENT_OPEN - BOLD_OPEN) / 2] &&
+                    !m_RangedActiveModifiers[(INLINE_MATH_OPEN - BOLD_OPEN) / 2] &&
+                    !m_RangedActiveModifiers[(VARIABLE_OPEN - BOLD_OPEN) / 2]
+                );
             };
-            */
 
             auto found_previous_attached_modifier = m_AttachedModifiers.find(m_Previous);
 
@@ -809,8 +817,8 @@ class Scanner
                 && !m_ActiveModifiers[(found_attached_modifier->second - BOLD_OPEN) / 2]
             )
             {
-                // if (can_have_modifier())
-                m_ActiveModifiers.set((found_attached_modifier->second - BOLD_OPEN) / 2);
+                if (can_have_modifier())
+                    m_ActiveModifiers.set((found_attached_modifier->second - BOLD_OPEN) / 2);
                 lexer->result_symbol = m_LastToken = found_attached_modifier->second;
                 return m_LastToken;
             }

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -815,8 +815,12 @@ class Scanner
         else
             advance(lexer);
 
+        auto found_next_attached_modifier = m_AttachedModifiers.find(lexer->lookahead);
+
         if (
-             m_RangedActiveModifiers[(found_attached_modifier->second - BOLD_OPEN) / 2] && std::iswpunct(lexer->lookahead)
+             m_RangedActiveModifiers[(found_attached_modifier->second - BOLD_OPEN) / 2] && (
+                 found_next_attached_modifier != m_AttachedModifiers.end() || lexer->lookahead == '|'
+            )
         )
         {
             m_ActiveModifiers.reset((found_attached_modifier->second - BOLD_OPEN) / 2);

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -679,10 +679,10 @@ class Scanner
                     lexer->result_symbol = m_LastToken = found_attached_modifier->second;
                     return m_LastToken;
                 }
-                // TODO(mrossinek): can this case actually occur?
-                else if (std::iswpunct(lexer->lookahead) && m_RangedActiveModifiers[(VARIABLE_OPEN - BOLD_OPEN) / 2])
+                else if (std::iswpunct(lexer->lookahead) && m_RangedActiveModifiers[(found_attached_modifier->second - BOLD_OPEN) / 2])
                 {
                     m_ActiveModifiers.reset((found_attached_modifier->second - BOLD_OPEN) / 2);
+                    m_RangedActiveModifiers.reset((found_attached_modifier->second - BOLD_OPEN) / 2);
                     lexer->result_symbol = m_LastToken =
                         static_cast<TokenType>(found_attached_modifier->second + 1);
                     return m_LastToken;
@@ -779,6 +779,20 @@ class Scanner
             };
             */
 
+            auto found_previous_attached_modifier = m_AttachedModifiers.find(m_Previous);
+
+            if (
+                (m_Previous == '|') || (
+                    found_previous_attached_modifier != m_AttachedModifiers.end()
+                    && found_previous_attached_modifier->second == m_LastToken
+                    && m_RangedActiveModifiers[(found_previous_attached_modifier->second - BOLD_OPEN) / 2]
+                )
+                )
+            {
+                m_RangedActiveModifiers.set((found_attached_modifier->second - BOLD_OPEN) / 2);
+            }
+
+
             if (
                 (!std::iswspace(lexer->lookahead) || (m_RangedActiveModifiers[(found_attached_modifier->second - BOLD_OPEN) / 2]))
                 && !m_ActiveModifiers[(found_attached_modifier->second - BOLD_OPEN) / 2]
@@ -786,8 +800,7 @@ class Scanner
             {
                 // if (can_have_modifier())
                 m_ActiveModifiers.set((found_attached_modifier->second - BOLD_OPEN) / 2);
-                if (m_Previous == '|')
-                    m_RangedActiveModifiers.set((found_attached_modifier->second - BOLD_OPEN) / 2);
+
                 lexer->result_symbol = m_LastToken = found_attached_modifier->second;
                 return m_LastToken;
             }
@@ -800,12 +813,12 @@ class Scanner
              (!std::iswspace(m_Previous) || !m_Previous) &&
              (std::iswspace(lexer->lookahead) || std::iswpunct(lexer->lookahead) || !lexer->lookahead)
             ) || (
-             std::iswspace(m_Previous) && m_RangedActiveModifiers[(found_attached_modifier->second - BOLD_OPEN) / 2] &&
-             lexer->lookahead == '|'
+             std::iswspace(m_Previous) && m_RangedActiveModifiers[(found_attached_modifier->second - BOLD_OPEN) / 2]
             )
         )
         {
             m_ActiveModifiers.reset((found_attached_modifier->second - BOLD_OPEN) / 2);
+            m_RangedActiveModifiers.reset((found_attached_modifier->second - BOLD_OPEN) / 2);
             lexer->result_symbol = m_LastToken =
                 static_cast<TokenType>(found_attached_modifier->second + 1);
             return m_LastToken;

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -816,16 +816,25 @@ class Scanner
             advance(lexer);
 
         if (
-            (
-             (!std::iswspace(m_Previous) || !m_Previous) &&
-             (std::iswspace(lexer->lookahead) || std::iswpunct(lexer->lookahead) || !lexer->lookahead)
-            ) || (
-             std::iswspace(m_Previous) && m_RangedActiveModifiers[(found_attached_modifier->second - BOLD_OPEN) / 2]
-            )
+             m_RangedActiveModifiers[(found_attached_modifier->second - BOLD_OPEN) / 2] && std::iswpunct(lexer->lookahead)
         )
         {
             m_ActiveModifiers.reset((found_attached_modifier->second - BOLD_OPEN) / 2);
             m_RangedActiveModifiers.reset((found_attached_modifier->second - BOLD_OPEN) / 2);
+            lexer->result_symbol = m_LastToken =
+                static_cast<TokenType>(found_attached_modifier->second + 1);
+            return m_LastToken;
+        }
+
+        if (
+            (
+             (!std::iswspace(m_Previous) || !m_Previous) &&
+             (std::iswspace(lexer->lookahead) || std::iswpunct(lexer->lookahead) || !lexer->lookahead)
+             && !m_RangedActiveModifiers[(found_attached_modifier->second - BOLD_OPEN) / 2]
+            )
+        )
+        {
+            m_ActiveModifiers.reset((found_attached_modifier->second - BOLD_OPEN) / 2);
             lexer->result_symbol = m_LastToken =
                 static_cast<TokenType>(found_attached_modifier->second + 1);
             return m_LastToken;

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -508,8 +508,14 @@ class Scanner
             else
                 return false;
         }
-        else if (m_LastToken >= UNORDERED_LIST1 && m_LastToken <= ORDERED_LIST6 &&
-                 lexer->lookahead == '|')
+        else if (
+            (lexer->lookahead == '|') &&
+            (
+                (m_LastToken >= UNORDERED_LIST1 && m_LastToken <= ORDERED_LIST6)
+                ||
+                (m_LastToken >= QUOTE1 && m_LastToken <= QUOTE6)
+            )
+            )
         {
             advance(lexer);
 

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -700,7 +700,7 @@ class Scanner
             {
                 auto found_attached_modifier = m_AttachedModifiers.find(lexer->lookahead);
 
-                if (found_attached_modifier != m_AttachedModifiers.end())
+                if (found_attached_modifier != m_AttachedModifiers.end() && !m_ActiveModifiers[(found_attached_modifier->second - BOLD_OPEN) / 2])
                 {
                     m_RangedActiveModifiers.set((found_attached_modifier->second - BOLD_OPEN) / 2);
                     lexer->result_symbol = m_LastToken = RANGED_MODIFIER_OPEN;
@@ -741,9 +741,10 @@ class Scanner
 
         if (lexer->lookahead == '|')
         {
+
             auto found_attached_modifier = m_AttachedModifiers.find(m_Current);
 
-            if (found_attached_modifier != m_AttachedModifiers.end())
+            if (found_attached_modifier != m_AttachedModifiers.end() && !m_ActiveModifiers[(found_attached_modifier->second - BOLD_OPEN) / 2])
             {
                 advance(lexer);
                 m_RangedActiveModifiers.reset((found_attached_modifier->second - BOLD_OPEN) / 2);
@@ -754,12 +755,14 @@ class Scanner
             advance(lexer);
 
             found_attached_modifier = m_AttachedModifiers.find(lexer->lookahead);
-            if (found_attached_modifier != m_AttachedModifiers.end())
+            if (found_attached_modifier != m_AttachedModifiers.end() && !m_ActiveModifiers[(found_attached_modifier->second - BOLD_OPEN) / 2])
             {
                 m_RangedActiveModifiers.set((found_attached_modifier->second - BOLD_OPEN) / 2);
                 lexer->result_symbol = m_LastToken = RANGED_MODIFIER_OPEN;
                 return m_LastToken;
             }
+
+            return NONE;
 
         }
 
@@ -790,7 +793,7 @@ class Scanner
             auto found_previous_attached_modifier = m_AttachedModifiers.find(m_Previous);
 
             if (
-                (m_Previous == '|') || (
+                (m_Previous == '|' && !m_ActiveModifiers[(found_attached_modifier->second - BOLD_OPEN) / 2]) || (
                     found_previous_attached_modifier != m_AttachedModifiers.end()
                     && found_previous_attached_modifier->second == m_LastToken
                     && m_RangedActiveModifiers[(found_previous_attached_modifier->second - BOLD_OPEN) / 2]
@@ -808,7 +811,6 @@ class Scanner
             {
                 // if (can_have_modifier())
                 m_ActiveModifiers.set((found_attached_modifier->second - BOLD_OPEN) / 2);
-
                 lexer->result_symbol = m_LastToken = found_attached_modifier->second;
                 return m_LastToken;
             }

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -790,11 +790,7 @@ class Scanner
                     !m_ActiveModifiers[(VERBATIM_OPEN - BOLD_OPEN) / 2] &&
                     !m_ActiveModifiers[(INLINE_COMMENT_OPEN - BOLD_OPEN) / 2] &&
                     !m_ActiveModifiers[(INLINE_MATH_OPEN - BOLD_OPEN) / 2] &&
-                    !m_ActiveModifiers[(VARIABLE_OPEN - BOLD_OPEN) / 2] &&
-                    !m_RangedActiveModifiers[(VERBATIM_OPEN - BOLD_OPEN) / 2] &&
-                    !m_RangedActiveModifiers[(INLINE_COMMENT_OPEN - BOLD_OPEN) / 2] &&
-                    !m_RangedActiveModifiers[(INLINE_MATH_OPEN - BOLD_OPEN) / 2] &&
-                    !m_RangedActiveModifiers[(VARIABLE_OPEN - BOLD_OPEN) / 2]
+                    !m_ActiveModifiers[(VARIABLE_OPEN - BOLD_OPEN) / 2]
                 );
             };
 

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -81,6 +81,8 @@ enum TokenType : char
     ORDERED_LINK5,
     ORDERED_LINK6,
 
+    INDENT_MODIFIER,
+
     STRONG_PARAGRAPH_DELIMITER,
     WEAK_PARAGRAPH_DELIMITER,
     HORIZONTAL_LINE,
@@ -501,6 +503,21 @@ class Scanner
             {
                 advance(lexer);
                 lexer->mark_end(lexer);
+                return true;
+            }
+            else
+                return false;
+        }
+        // If we are not in a tag and we have a square bracket opening then try
+        // matching either a todo item or beginning of a list
+        else if (m_LastToken >= UNORDERED_LIST1 && m_LastToken <= ORDERED_LIST6 &&
+                 lexer->lookahead == '|')
+        {
+            advance(lexer);
+
+            if (lexer->lookahead == '\n')
+            {
+                lexer->result_symbol = m_LastToken = INDENT_MODIFIER;
                 return true;
             }
             else

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -508,8 +508,6 @@ class Scanner
             else
                 return false;
         }
-        // If we are not in a tag and we have a square bracket opening then try
-        // matching either a todo item or beginning of a list
         else if (m_LastToken >= UNORDERED_LIST1 && m_LastToken <= ORDERED_LIST6 &&
                  lexer->lookahead == '|')
         {

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -760,8 +760,6 @@ class Scanner
         if (found_attached_modifier == m_AttachedModifiers.end())
             return NONE;
 
-        int32_t cur = m_Current;
-
         // First check for the existence of an opening attached modifier
         if (std::iswspace(m_Current) || std::iswpunct(m_Current) || !m_Current)
         {
@@ -799,10 +797,10 @@ class Scanner
 
         if (
             (
-             (!std::iswspace(cur) || !cur) &&
+             (!std::iswspace(m_Previous) || !m_Previous) &&
              (std::iswspace(lexer->lookahead) || std::iswpunct(lexer->lookahead) || !lexer->lookahead)
             ) || (
-             std::iswspace(cur) && m_RangedActiveModifiers[(found_attached_modifier->second - BOLD_OPEN) / 2] &&
+             std::iswspace(m_Previous) && m_RangedActiveModifiers[(found_attached_modifier->second - BOLD_OPEN) / 2] &&
              lexer->lookahead == '|'
             )
         )

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -227,8 +227,7 @@ class Scanner
             {
                 advance(lexer);
                 lexer->result_symbol = m_LastToken = PARAGRAPH_BREAK;
-                if (!m_RangedActiveModifiers.any())
-                    m_ActiveModifiers.reset();
+                reset_active_modifiers();
             }
 
             return true;
@@ -641,6 +640,7 @@ class Scanner
 
                 lexer->result_symbol = m_LastToken = result;
 
+                reset_active_modifiers();
                 return result;
             }
 
@@ -668,6 +668,7 @@ class Scanner
 
                 lexer->result_symbol = m_LastToken = result;
 
+                reset_active_modifiers();
                 return result;
             }
         }
@@ -996,6 +997,15 @@ class Scanner
     T clamp(T value, Comp min, Comp max)
     {
         return value < min ? min : (value > max ? max : value);
+    }
+
+    void reset_active_modifiers()
+    {
+        for (int i = 0; i < m_RangedActiveModifiers.size(); i++)
+        {
+            if (!m_RangedActiveModifiers[i])
+                m_ActiveModifiers.reset(i);
+        }
     }
 
    private:

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -905,7 +905,7 @@ class Scanner
                                                         '~', '$', '_', '^'};
     const std::unordered_map<char, TokenType> m_AttachedModifiers = {
         {'*', BOLD_OPEN},        {'/', ITALIC_OPEN},    {'-', STRIKETHROUGH_OPEN},
-        {'_', UNDERLINE_OPEN},   {'|', SPOILER_OPEN},   {'`', VERBATIM_OPEN},
+        {'_', UNDERLINE_OPEN},   {'!', SPOILER_OPEN},   {'`', VERBATIM_OPEN},
         {'^', SUPERSCRIPT_OPEN}, {',', SUBSCRIPT_OPEN}, {'+', INLINE_COMMENT_OPEN},
         {'$', INLINE_MATH_OPEN}, {'=', VARIABLE_OPEN},
     };

--- a/test/corpus/indent_segments.txt
+++ b/test/corpus/indent_segments.txt
@@ -1,0 +1,25 @@
+======================
+Indent Segment in List
+======================
+- |
+  Indent list item
+
+  which continues here.
+- a normal list item which ends the list.
+---
+(document
+  (generic_list
+    (unordered_list1
+      (unordered_list1_prefix)
+      (indent_segment
+        (indent_modifier)
+        (paragraph (paragraph_segment))
+        (paragraph (paragraph_segment))
+      )
+    )
+    (unordered_list1
+      (unordered_list1_prefix)
+      (paragraph (paragraph_segment))
+    )
+  )
+)

--- a/test/corpus/indent_segments.txt
+++ b/test/corpus/indent_segments.txt
@@ -11,14 +11,36 @@ Indent Segment in List
   (generic_list
     (unordered_list1
       (unordered_list1_prefix)
-      (indent_segment
-        (indent_modifier)
-        (paragraph (paragraph_segment))
-        (paragraph (paragraph_segment))
-      )
+      (indent_modifier)
+      (paragraph (paragraph_segment))
+      (paragraph (paragraph_segment))
     )
     (unordered_list1
       (unordered_list1_prefix)
+      (paragraph (paragraph_segment))
+    )
+  )
+)
+
+=======================
+Indent Segment in Quote
+=======================
+> |
+  Indent quote
+
+  which continues here.
+> a normal quote which ends the quote
+---
+(document
+  (quote
+    (quote1
+      (quote1_prefix)
+      (indent_modifier)
+      (paragraph (paragraph_segment))
+      (paragraph (paragraph_segment))
+    )
+    (quote1
+      (quote1_prefix)
       (paragraph (paragraph_segment))
     )
   )

--- a/test/corpus/markup.txt
+++ b/test/corpus/markup.txt
@@ -661,9 +661,13 @@ No nested markup inside verbatim
 `=no variable=`
 `no:*link modifier*`
 `hidden \*escaped char`
+`|`
 ---
 (document
     (paragraph
+        (paragraph_segment
+            (verbatim)
+        )
         (paragraph_segment
             (verbatim)
         )
@@ -718,9 +722,13 @@ No nested markup inside inline comments
 +=no variable=+
 +no:*link modifier*+
 +hidden \*escaped char*+
++|+
 ---
 (document
     (paragraph
+        (paragraph_segment
+            (inline_comment)
+        )
         (paragraph_segment
             (inline_comment)
         )
@@ -775,9 +783,13 @@ $+no inline comment+$
 $=no variable=$
 $no:*link modifier*$
 $hidden \*escaped char*$
+$|$
 ---
 (document
     (paragraph
+        (paragraph_segment
+            (inline_math)
+        )
         (paragraph_segment
             (inline_math)
         )
@@ -832,9 +844,13 @@ No nested markup inside variables
 =$no inline math$=
 =no:*link modifier*=
 =hidden \*escaped char*=
+=|=
 ---
 (document
     (paragraph
+        (paragraph_segment
+            (variable)
+        )
         (paragraph_segment
             (variable)
         )

--- a/test/corpus/markup.txt
+++ b/test/corpus/markup.txt
@@ -66,7 +66,7 @@ Here is an _underlined_ word.
 =======
 Spoiler
 =======
-Here is a |spoiler| word.
+Here is a !spoiler! word.
 ---
 (document
     (paragraph
@@ -160,7 +160,7 @@ Nesting into Bold
 *Bold and /italic/*
 *Bold and -struck through-*
 *Bold and _underlined_*
-*Bold and |spoiler|*
+*Bold and !spoiler!*
 *Bold and ^superscript^*
 *Bold and ,subscript,*
 ---
@@ -205,7 +205,7 @@ Nesting into Italic
 /Italic and *bold*/
 /Italic and -struck through-/
 /Italic and _underlined_/
-/Italic and |spoiler|/
+/Italic and !spoiler!/
 /Italic and ^superscript^/
 /Italic and ,subscript,/
 ---
@@ -250,7 +250,7 @@ Nesting into Strikethrough
 -Struck through and *bold*-
 -Struck through and /italic/-
 -Struck through and _underlined_-
--Struck through and |spoiler|-
+-Struck through and !spoiler!-
 -Struck through and ^superscript^-
 -Struck through and ,subscript,-
 ---
@@ -295,7 +295,7 @@ Nesting into Underline
 _Underlined and *bold*_
 _Underlined and /italic/_
 _Underlined and -struck through-_
-_Underlined and |spoiler|_
+_Underlined and !spoiler!_
 _Underlined and ^superscript^_
 _Underlined and ,subscript,_
 ---
@@ -337,12 +337,12 @@ _Underlined and ,subscript,_
 ====================
 Nesting into Spoiler
 ====================
-|Spoiler and *bold*|
-|Spoiler and /italic/|
-|Spoiler and -struck through-|
-|Spoiler and _underlined_|
-|Spoiler and ^superscript^|
-|Spoiler and ,subscript,|
+!Spoiler and *bold*!
+!Spoiler and /italic/!
+!Spoiler and -struck through-!
+!Spoiler and _underlined_!
+!Spoiler and ^superscript^!
+!Spoiler and ,subscript,!
 ---
 (document
     (paragraph
@@ -386,7 +386,7 @@ Nesting into Superscript
 ^Superscript and /italic/^
 ^Superscript and -struck through-^
 ^Superscript and _underlined_^
-^Superscript and |spoiler|^
+^Superscript and !spoiler!^
 ---
 (document
     (paragraph
@@ -425,7 +425,7 @@ Nesting into Subscript
 ,Subscript and /italic/,
 ,Subscript and -struck through-,
 ,Subscript and _underlined_,
-,Subscript and |spoiler|,
+,Subscript and !spoiler!,
 ---
 (document
     (paragraph
@@ -483,7 +483,7 @@ This is not ** bold.
 This is not // italic.
 This is not -- struck through.
 This is not __ underlined.
-This is not || a spoiler.
+This is not !! a spoiler.
 This is not `` verbatim.
 This is not ^^ superscript.
 This is not ,, subscript.
@@ -514,7 +514,7 @@ This is not \*bold\*
 This is not \/italic\/
 This is not \-struck through\-
 This is not \_underlined\_
-This is not \|a spoiler\|
+This is not \!a spoiler\!
 This is not \`verbatim\`
 This is not \^superscript\^
 This is not \,subscript\,
@@ -578,7 +578,7 @@ Intra:*word*:bold
 Intra:/word/:italic
 Intra:-word-:strikethrough
 Intra:_word_:underline
-Intra:|word|:spoiler
+Intra:!word!:spoiler
 Intra:^word^:superscript
 Intra:,word,:subscript
 Intra:`word`:verbatim
@@ -653,7 +653,7 @@ No nested markup inside verbatim
 `/not italic/`
 `-not struck through-`
 `_not underlined_`
-`|no spoiler|`
+`!no spoiler!`
 `^not superscripted^`
 `,not subscripted,`
 `+no inline comment+`
@@ -710,7 +710,7 @@ No nested markup inside inline comments
 +/not italic/+
 +-not struck through-+
 +_not underlined_+
-+|no spoiler|+
++!no spoiler!+
 +^not superscripted^+
 +,not subscripted,+
 +`no verbatim`+
@@ -767,7 +767,7 @@ $*not bold*$
 $/not italic/$
 $-not struck through-$
 $_not underlined_$
-$|no spoiler|$
+$!no spoiler!$
 $^not superscripted^$
 $,not subscripted,$
 $`no verbatim`$
@@ -824,7 +824,7 @@ No nested markup inside variables
 =/not italic/=
 =-not struck through-=
 =_not underlined_=
-=|no spoiler|=
+=!no spoiler!=
 =^not superscripted^=
 =,not subscripted,=
 =`no verbatim`=

--- a/test/corpus/quotes.txt
+++ b/test/corpus/quotes.txt
@@ -2,13 +2,14 @@
 Level 1 Quotes
 ==============
 > This is a first level quote.
+
 This is no longer part of the quote.
 ---
 (document
     (quote
         (quote1
             (quote1_prefix)
-            content: (paragraph_segment)
+            content: (paragraph (paragraph_segment))
         )
     )
     (paragraph (paragraph_segment))
@@ -18,13 +19,14 @@ This is no longer part of the quote.
 Level 2 Quotes
 ==============
 >> This is a second level quote.
+
 This is no longer part of the quote.
 ---
 (document
     (quote
         (quote2
             (quote2_prefix)
-            content: (paragraph_segment)
+            content: (paragraph (paragraph_segment))
         )
     )
     (paragraph (paragraph_segment))
@@ -34,13 +36,14 @@ This is no longer part of the quote.
 Level 3 Quotes
 ==============
 >>> This is a third level quote.
+
 This is no longer part of the quote.
 ---
 (document
     (quote
         (quote3
             (quote3_prefix)
-            content: (paragraph_segment)
+            content: (paragraph (paragraph_segment))
         )
     )
     (paragraph (paragraph_segment))
@@ -50,13 +53,14 @@ This is no longer part of the quote.
 Level 4 Quotes
 ==============
 >>>> This is a forth level quote.
+
 This is no longer part of the quote.
 ---
 (document
     (quote
         (quote4
             (quote4_prefix)
-            content: (paragraph_segment)
+            content: (paragraph (paragraph_segment))
         )
     )
     (paragraph (paragraph_segment))
@@ -66,13 +70,14 @@ This is no longer part of the quote.
 Level 5 Quotes
 ==============
 >>>>> This is a fifth level quote.
+
 This is no longer part of the quote.
 ---
 (document
     (quote
         (quote5
             (quote5_prefix)
-            content: (paragraph_segment)
+            content: (paragraph (paragraph_segment))
         )
     )
     (paragraph (paragraph_segment))
@@ -82,13 +87,14 @@ This is no longer part of the quote.
 Level 6 Quotes
 ==============
 >>>>>> This is a sixth level quote.
+
 This is no longer part of the quote.
 ---
 (document
     (quote
         (quote6
             (quote6_prefix)
-            content: (paragraph_segment)
+            content: (paragraph (paragraph_segment))
         )
     )
     (paragraph (paragraph_segment))
@@ -98,13 +104,14 @@ This is no longer part of the quote.
 Fallback to Level 6 Quotes
 ==========================
 >>>>>>> This falls back to a sixth level quote.
+
 This is no longer part of the quote.
 ---
 (document
     (quote
         (quote6
             (quote6_prefix)
-            content: (paragraph_segment)
+            content: (paragraph (paragraph_segment))
         )
     )
     (paragraph (paragraph_segment))
@@ -126,61 +133,62 @@ Nested Quotes
 >>> Here, the third level quote continues.
 >> Here, the second level quote continues.
 > Here, the first level quote continues.
+
 This is no longer part of the quote.
 ---
 (document
     (quote
         (quote1
             (quote1_prefix)
-            content: (paragraph_segment)
+            content: (paragraph (paragraph_segment))
             (quote2
                 (quote2_prefix)
-                content: (paragraph_segment)
+                content: (paragraph (paragraph_segment))
                 (quote3
                     (quote3_prefix)
-                    content: (paragraph_segment)
+                    content: (paragraph (paragraph_segment))
                     (quote4
                         (quote4_prefix)
-                        content: (paragraph_segment)
+                        content: (paragraph (paragraph_segment))
                         (quote5
                             (quote5_prefix)
-                            content: (paragraph_segment)
+                            content: (paragraph (paragraph_segment))
                             (quote6
                                 (quote6_prefix)
-                                content: (paragraph_segment)
+                                content: (paragraph (paragraph_segment))
                             )
                             (quote6
                                 (quote6_prefix)
-                                content: (paragraph_segment)
+                                content: (paragraph (paragraph_segment))
                             )
                             (quote6
                                 (quote6_prefix)
-                                content: (paragraph_segment)
+                                content: (paragraph (paragraph_segment))
                             )
                         )
                         (quote5
                             (quote5_prefix)
-                            content: (paragraph_segment)
+                            content: (paragraph (paragraph_segment))
                         )
                     )
                     (quote4
                         (quote4_prefix)
-                        content: (paragraph_segment)
+                        content: (paragraph (paragraph_segment))
                     )
                 )
                 (quote3
                     (quote3_prefix)
-                    content: (paragraph_segment)
+                    content: (paragraph (paragraph_segment))
                 )
             )
             (quote2
                 (quote2_prefix)
-                content: (paragraph_segment)
+                content: (paragraph (paragraph_segment))
             )
         )
         (quote1
             (quote1_prefix)
-            content: (paragraph_segment)
+            content: (paragraph (paragraph_segment))
         )
     )
     (paragraph (paragraph_segment))
@@ -192,19 +200,20 @@ Quote End
 > This is one quote.
 
 > And this is another.
+
 This is no longer part of the quote.
 ---
 (document
     (quote
         (quote1
             (quote1_prefix)
-            content: (paragraph_segment)
+            content: (paragraph (paragraph_segment))
         )
     )
     (quote
         (quote1
             (quote1_prefix)
-            content: (paragraph_segment)
+            content: (paragraph (paragraph_segment))
         )
     )
     (paragraph (paragraph_segment))

--- a/test/corpus/ranged_markup.txt
+++ b/test/corpus/ranged_markup.txt
@@ -14,22 +14,22 @@ bold *| markup.
 (document
     (paragraph
         (paragraph_segment
-            (ranged_bold)
+            (ranged_attached_modifier (bold))
         )
         (paragraph_segment
-            (ranged_bold)
+            (ranged_attached_modifier (bold))
         )
         (paragraph_segment
-            (ranged_bold)
+            (ranged_attached_modifier (bold))
         )
         (paragraph_segment
-            (ranged_bold)
+            (ranged_attached_modifier (bold))
         )
         (paragraph_segment
-            (ranged_bold)
+            (ranged_attached_modifier (bold))
         )
         (paragraph_segment
-            (ranged_bold)
+            (ranged_attached_modifier (bold))
         )
     )
 )
@@ -50,22 +50,22 @@ italic /| markup.
 (document
     (paragraph
         (paragraph_segment
-            (ranged_italic)
+            (ranged_attached_modifier (italic))
         )
         (paragraph_segment
-            (ranged_italic)
+            (ranged_attached_modifier (italic))
         )
         (paragraph_segment
-            (ranged_italic)
+            (ranged_attached_modifier (italic))
         )
         (paragraph_segment
-            (ranged_italic)
+            (ranged_attached_modifier (italic))
         )
         (paragraph_segment
-            (ranged_italic)
+            (ranged_attached_modifier (italic))
         )
         (paragraph_segment
-            (ranged_italic)
+            (ranged_attached_modifier (italic))
         )
     )
 )
@@ -86,22 +86,22 @@ strikethrough -| markup.
 (document
     (paragraph
         (paragraph_segment
-            (ranged_strikethrough)
+            (ranged_attached_modifier (strikethrough))
         )
         (paragraph_segment
-            (ranged_strikethrough)
+            (ranged_attached_modifier (strikethrough))
         )
         (paragraph_segment
-            (ranged_strikethrough)
+            (ranged_attached_modifier (strikethrough))
         )
         (paragraph_segment
-            (ranged_strikethrough)
+            (ranged_attached_modifier (strikethrough))
         )
         (paragraph_segment
-            (ranged_strikethrough)
+            (ranged_attached_modifier (strikethrough))
         )
         (paragraph_segment
-            (ranged_strikethrough)
+            (ranged_attached_modifier (strikethrough))
         )
     )
 )
@@ -122,22 +122,22 @@ underline _| markup.
 (document
     (paragraph
         (paragraph_segment
-            (ranged_underline)
+            (ranged_attached_modifier (underline))
         )
         (paragraph_segment
-            (ranged_underline)
+            (ranged_attached_modifier (underline))
         )
         (paragraph_segment
-            (ranged_underline)
+            (ranged_attached_modifier (underline))
         )
         (paragraph_segment
-            (ranged_underline)
+            (ranged_attached_modifier (underline))
         )
         (paragraph_segment
-            (ranged_underline)
+            (ranged_attached_modifier (underline))
         )
         (paragraph_segment
-            (ranged_underline)
+            (ranged_attached_modifier (underline))
         )
     )
 )
@@ -158,22 +158,22 @@ spoiler !| markup.
 (document
     (paragraph
         (paragraph_segment
-            (ranged_spoiler)
+            (ranged_attached_modifier (spoiler))
         )
         (paragraph_segment
-            (ranged_spoiler)
+            (ranged_attached_modifier (spoiler))
         )
         (paragraph_segment
-            (ranged_spoiler)
+            (ranged_attached_modifier (spoiler))
         )
         (paragraph_segment
-            (ranged_spoiler)
+            (ranged_attached_modifier (spoiler))
         )
         (paragraph_segment
-            (ranged_spoiler)
+            (ranged_attached_modifier (spoiler))
         )
         (paragraph_segment
-            (ranged_spoiler)
+            (ranged_attached_modifier (spoiler))
         )
     )
 )
@@ -194,22 +194,22 @@ superscript ^| markup.
 (document
     (paragraph
         (paragraph_segment
-            (ranged_superscript)
+            (ranged_attached_modifier (superscript))
         )
         (paragraph_segment
-            (ranged_superscript)
+            (ranged_attached_modifier (superscript))
         )
         (paragraph_segment
-            (ranged_superscript)
+            (ranged_attached_modifier (superscript))
         )
         (paragraph_segment
-            (ranged_superscript)
+            (ranged_attached_modifier (superscript))
         )
         (paragraph_segment
-            (ranged_superscript)
+            (ranged_attached_modifier (superscript))
         )
         (paragraph_segment
-            (ranged_superscript)
+            (ranged_attached_modifier (superscript))
         )
     )
 )
@@ -230,22 +230,22 @@ subscript ,| markup.
 (document
     (paragraph
         (paragraph_segment
-            (ranged_subscript)
+            (ranged_attached_modifier (subscript))
         )
         (paragraph_segment
-            (ranged_subscript)
+            (ranged_attached_modifier (subscript))
         )
         (paragraph_segment
-            (ranged_subscript)
+            (ranged_attached_modifier (subscript))
         )
         (paragraph_segment
-            (ranged_subscript)
+            (ranged_attached_modifier (subscript))
         )
         (paragraph_segment
-            (ranged_subscript)
+            (ranged_attached_modifier (subscript))
         )
         (paragraph_segment
-            (ranged_subscript)
+            (ranged_attached_modifier (subscript))
         )
     )
 )
@@ -266,22 +266,22 @@ verbatim `| markup.
 (document
     (paragraph
         (paragraph_segment
-            (ranged_verbatim)
+            (ranged_attached_modifier (verbatim))
         )
         (paragraph_segment
-            (ranged_verbatim)
+            (ranged_attached_modifier (verbatim))
         )
         (paragraph_segment
-            (ranged_verbatim)
+            (ranged_attached_modifier (verbatim))
         )
         (paragraph_segment
-            (ranged_verbatim)
+            (ranged_attached_modifier (verbatim))
         )
         (paragraph_segment
-            (ranged_verbatim)
+            (ranged_attached_modifier (verbatim))
         )
         (paragraph_segment
-            (ranged_verbatim)
+            (ranged_attached_modifier (verbatim))
         )
     )
 )
@@ -302,22 +302,22 @@ inline_comment +| markup.
 (document
     (paragraph
         (paragraph_segment
-            (ranged_inline_comment)
+            (ranged_attached_modifier (inline_comment))
         )
         (paragraph_segment
-            (ranged_inline_comment)
+            (ranged_attached_modifier (inline_comment))
         )
         (paragraph_segment
-            (ranged_inline_comment)
+            (ranged_attached_modifier (inline_comment))
         )
         (paragraph_segment
-            (ranged_inline_comment)
+            (ranged_attached_modifier (inline_comment))
         )
         (paragraph_segment
-            (ranged_inline_comment)
+            (ranged_attached_modifier (inline_comment))
         )
         (paragraph_segment
-            (ranged_inline_comment)
+            (ranged_attached_modifier (inline_comment))
         )
     )
 )
@@ -338,22 +338,22 @@ inline_math $| markup.
 (document
     (paragraph
         (paragraph_segment
-            (ranged_inline_math)
+            (ranged_attached_modifier (inline_math))
         )
         (paragraph_segment
-            (ranged_inline_math)
+            (ranged_attached_modifier (inline_math))
         )
         (paragraph_segment
-            (ranged_inline_math)
+            (ranged_attached_modifier (inline_math))
         )
         (paragraph_segment
-            (ranged_inline_math)
+            (ranged_attached_modifier (inline_math))
         )
         (paragraph_segment
-            (ranged_inline_math)
+            (ranged_attached_modifier (inline_math))
         )
         (paragraph_segment
-            (ranged_inline_math)
+            (ranged_attached_modifier (inline_math))
         )
     )
 )
@@ -374,22 +374,22 @@ variable =| markup.
 (document
     (paragraph
         (paragraph_segment
-            (ranged_variable)
+            (ranged_attached_modifier (variable))
         )
         (paragraph_segment
-            (ranged_variable)
+            (ranged_attached_modifier (variable))
         )
         (paragraph_segment
-            (ranged_variable)
+            (ranged_attached_modifier (variable))
         )
         (paragraph_segment
-            (ranged_variable)
+            (ranged_attached_modifier (variable))
         )
         (paragraph_segment
-            (ranged_variable)
+            (ranged_attached_modifier (variable))
         )
         (paragraph_segment
-            (ranged_variable)
+            (ranged_attached_modifier (variable))
         )
     )
 )

--- a/test/corpus/ranged_markup.txt
+++ b/test/corpus/ranged_markup.txt
@@ -393,4 +393,3 @@ variable =| markup.
         )
     )
 )
-

--- a/test/corpus/ranged_markup.txt
+++ b/test/corpus/ranged_markup.txt
@@ -34,9 +34,9 @@ bold *| markup.
     )
 )
 
-===========
+=============
 Ranged Italic
-===========
+=============
 Here is some |/ranged italic/| markup.
 Here is some |/ ranged italic/| markup.
 Here is some |/ranged italic /| markup.
@@ -70,9 +70,9 @@ italic /| markup.
     )
 )
 
-===========
+====================
 Ranged Strikethrough
-===========
+====================
 Here is some |-ranged strikethrough-| markup.
 Here is some |- ranged strikethrough-| markup.
 Here is some |-ranged strikethrough -| markup.
@@ -106,9 +106,9 @@ strikethrough -| markup.
     )
 )
 
-===========
+================
 Ranged Underline
-===========
+================
 Here is some |_ranged underline_| markup.
 Here is some |_ ranged underline_| markup.
 Here is some |_ranged underline _| markup.
@@ -142,9 +142,9 @@ underline _| markup.
     )
 )
 
-===========
+==============
 Ranged Spoiler
-===========
+==============
 Here is some |!ranged spoiler!| markup.
 Here is some |! ranged spoiler!| markup.
 Here is some |!ranged spoiler !| markup.
@@ -178,9 +178,9 @@ spoiler !| markup.
     )
 )
 
-===========
+==================
 Ranged Superscript
-===========
+==================
 Here is some |^ranged superscript^| markup.
 Here is some |^ ranged superscript^| markup.
 Here is some |^ranged superscript ^| markup.
@@ -214,9 +214,9 @@ superscript ^| markup.
     )
 )
 
-===========
+================
 Ranged Subscript
-===========
+================
 Here is some |,ranged subscript,| markup.
 Here is some |, ranged subscript,| markup.
 Here is some |,ranged subscript ,| markup.
@@ -250,9 +250,9 @@ subscript ,| markup.
     )
 )
 
-===========
+===============
 Ranged Verbatim
-===========
+===============
 Here is some |`ranged verbatim`| markup.
 Here is some |` ranged verbatim`| markup.
 Here is some |`ranged verbatim `| markup.
@@ -286,9 +286,9 @@ verbatim `| markup.
     )
 )
 
-===========
+=====================
 Ranged Inline Comment
-===========
+=====================
 Here is some |+ranged inline_comment+| markup.
 Here is some |+ ranged inline_comment+| markup.
 Here is some |+ranged inline_comment +| markup.
@@ -322,9 +322,9 @@ inline_comment +| markup.
     )
 )
 
-===========
+==================
 Ranged Inline Math
-===========
+==================
 Here is some |$ranged inline_math$| markup.
 Here is some |$ ranged inline_math$| markup.
 Here is some |$ranged inline_math $| markup.
@@ -358,9 +358,9 @@ inline_math $| markup.
     )
 )
 
-===========
+===============
 Ranged Variable
-===========
+===============
 Here is some |=ranged variable=| markup.
 Here is some |= ranged variable=| markup.
 Here is some |=ranged variable =| markup.
@@ -373,6 +373,1078 @@ variable =| markup.
 ---
 (document
     (paragraph
+        (paragraph_segment
+            (ranged_attached_modifier (variable))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (variable))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (variable))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (variable))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (variable))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (variable))
+        )
+    )
+)
+
+========================
+Nesting into Ranged Bold
+========================
+|*Bold and /italic/*|
+|*Bold and -struck through-*|
+|*Bold and _underlined_*|
+|*Bold and !spoiler!*|
+|*Bold and ^superscript^*|
+|*Bold and ,subscript,*|
+|*Bold and |/italic/|*|
+|*Bold and |-struck through-|*|
+|*Bold and |_underlined_|*|
+|*Bold and |!spoiler!|*|
+|*Bold and |^superscript^|*|
+|*Bold and |,subscript,|*|
+---
+(document
+    (paragraph
+        (paragraph_segment
+            (ranged_attached_modifier
+                (bold
+                    (italic)
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (bold
+                    (strikethrough)
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (bold
+                    (underline)
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (bold
+                    (spoiler)
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (bold
+                    (superscript)
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (bold
+                    (subscript)
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (bold
+                    (ranged_attached_modifier (italic))
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (bold
+                    (ranged_attached_modifier (strikethrough))
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (bold
+                    (ranged_attached_modifier (underline))
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (bold
+                    (ranged_attached_modifier (spoiler))
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (bold
+                    (ranged_attached_modifier (superscript))
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (bold
+                    (ranged_attached_modifier (subscript))
+                )
+            )
+        )
+    )
+)
+
+==========================
+Nesting into Ranged Italic
+==========================
+|/Italic and *bold*/|
+|/Italic and -struck through-/|
+|/Italic and _underlined_/|
+|/Italic and !spoiler!/|
+|/Italic and ^superscript^/|
+|/Italic and ,subscript,/|
+|/Italic and |*bold*|/|
+|/Italic and |-struck through-|/|
+|/Italic and |_underlined_|/|
+|/Italic and |!spoiler!|/|
+|/Italic and |^superscript^|/|
+|/Italic and |,subscript,|/|
+---
+(document
+    (paragraph
+        (paragraph_segment
+            (ranged_attached_modifier
+                (italic (bold))
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (italic (strikethrough))
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (italic (underline))
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (italic (spoiler))
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (italic (superscript))
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (italic (subscript))
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (italic
+                    (ranged_attached_modifier (bold))
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (italic
+                    (ranged_attached_modifier (strikethrough))
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (italic
+                    (ranged_attached_modifier (underline))
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (italic
+                    (ranged_attached_modifier (spoiler))
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (italic
+                    (ranged_attached_modifier (superscript))
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (italic
+                    (ranged_attached_modifier (subscript))
+                )
+            )
+        )
+    )
+)
+
+=================================
+Nesting into Ranged Strikethrough
+=================================
+|-Strikethrough and *bold*-|
+|-Strikethrough and /italic/-|
+|-Strikethrough and _underlined_-|
+|-Strikethrough and !spoiler!-|
+|-Strikethrough and ^superscript^-|
+|-Strikethrough and ,subscript,-|
+|-Strikethrough and |*bold*|-|
+|-Strikethrough and |/italic/|-|
+|-Strikethrough and |_underlined_|-|
+|-Strikethrough and |!spoiler!|-|
+|-Strikethrough and |^superscript^|-|
+|-Strikethrough and |,subscript,|-|
+---
+(document
+    (paragraph
+        (paragraph_segment
+            (ranged_attached_modifier
+                (strikethrough (bold))
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (strikethrough (italic))
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (strikethrough (underline))
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (strikethrough (spoiler))
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (strikethrough (superscript))
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (strikethrough (subscript))
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (strikethrough
+                    (ranged_attached_modifier (bold))
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (strikethrough
+                    (ranged_attached_modifier (italic))
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (strikethrough
+                    (ranged_attached_modifier (underline))
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (strikethrough
+                    (ranged_attached_modifier (spoiler))
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (strikethrough
+                    (ranged_attached_modifier (superscript))
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (strikethrough
+                    (ranged_attached_modifier (subscript))
+                )
+            )
+        )
+    )
+)
+
+=============================
+Nesting into Ranged Underline
+=============================
+|_Underline and *bold*_|
+|_Underline and /italic/_|
+|_Underline and -struck through-_|
+|_Underline and !spoiler!_|
+|_Underline and ^superscript^_|
+|_Underline and ,subscript,_|
+|_Underline and |*bold*|_|
+|_Underline and |/italic/|_|
+|_Underline and |-strikethrough-|_|
+|_Underline and |!spoiler!|_|
+|_Underline and |^superscript^|_|
+|_Underline and |,subscript,|_|
+---
+(document
+    (paragraph
+        (paragraph_segment
+            (ranged_attached_modifier
+                (underline (bold))
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (underline (italic))
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (underline (strikethrough))
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (underline (spoiler))
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (underline (superscript))
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (underline (subscript))
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (underline
+                    (ranged_attached_modifier (bold))
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (underline
+                    (ranged_attached_modifier (italic))
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (underline
+                    (ranged_attached_modifier (strikethrough))
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (underline
+                    (ranged_attached_modifier (spoiler))
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (underline
+                    (ranged_attached_modifier (superscript))
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (underline
+                    (ranged_attached_modifier (subscript))
+                )
+            )
+        )
+    )
+)
+
+===========================
+Nesting into Ranged Spoiler
+===========================
+|!Spoiler and *bold*!|
+|!Spoiler and /italic/!|
+|!Spoiler and -struck through-!|
+|!Spoiler and _underline_!|
+|!Spoiler and ^superscript^!|
+|!Spoiler and ,subscript,!|
+|!Spoiler and |*bold*|!|
+|!Spoiler and |/italic/|!|
+|!Spoiler and |-strikethrough-|!|
+|!Spoiler and |_underline_|!|
+|!Spoiler and |^superscript^|!|
+|!Spoiler and |,subscript,|!|
+---
+(document
+    (paragraph
+        (paragraph_segment
+            (ranged_attached_modifier
+                (spoiler (bold))
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (spoiler (italic))
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (spoiler (strikethrough))
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (spoiler (underline))
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (spoiler (superscript))
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (spoiler (subscript))
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (spoiler
+                    (ranged_attached_modifier (bold))
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (spoiler
+                    (ranged_attached_modifier (italic))
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (spoiler
+                    (ranged_attached_modifier (strikethrough))
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (spoiler
+                    (ranged_attached_modifier (underline))
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (spoiler
+                    (ranged_attached_modifier (superscript))
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (spoiler
+                    (ranged_attached_modifier (subscript))
+                )
+            )
+        )
+    )
+)
+
+===============================
+Nesting into Ranged Superscript
+===============================
+|^Superscript and *bold*^|
+|^Superscript and /italic/^|
+|^Superscript and -struck through-^|
+|^Superscript and _underline_^|
+|^Superscript and !spoiler!^|
+|^Superscript and ,subscript,^|
+|^Superscript and |*bold*|^|
+|^Superscript and |/italic/|^|
+|^Superscript and |-strikethrough-|^|
+|^Superscript and |_underline_|^|
+|^Superscript and |!spoiler!|^|
+|^Superscript and |,subscript,|^|
+---
+(document
+    (paragraph
+        (paragraph_segment
+            (ranged_attached_modifier
+                (superscript (bold))
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (superscript (italic))
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (superscript (strikethrough))
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (superscript (underline))
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (superscript (spoiler))
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (superscript (subscript))
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (superscript
+                    (ranged_attached_modifier (bold))
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (superscript
+                    (ranged_attached_modifier (italic))
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (superscript
+                    (ranged_attached_modifier (strikethrough))
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (superscript
+                    (ranged_attached_modifier (underline))
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (superscript
+                    (ranged_attached_modifier (spoiler))
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (superscript
+                    (ranged_attached_modifier (subscript))
+                )
+            )
+        )
+    )
+)
+
+=============================
+Nesting into Ranged Subscript
+=============================
+|,Subscript and *bold*,|
+|,Subscript and /italic/,|
+|,Subscript and -struck through-,|
+|,Subscript and _underline_,|
+|,Subscript and !spoiler!,|
+|,Subscript and ^superscript^,|
+|,Subscript and |*bold*|,|
+|,Subscript and |/italic/|,|
+|,Subscript and |-strikethrough-|,|
+|,Subscript and |_underline_|,|
+|,Subscript and |!spoiler!|,|
+|,Subscript and |^superscript^|,|
+---
+(document
+    (paragraph
+        (paragraph_segment
+            (ranged_attached_modifier
+                (subscript (bold))
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (subscript (italic))
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (subscript (strikethrough))
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (subscript (underline))
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (subscript (spoiler))
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (subscript (superscript))
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (subscript
+                    (ranged_attached_modifier (bold))
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (subscript
+                    (ranged_attached_modifier (italic))
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (subscript
+                    (ranged_attached_modifier (strikethrough))
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (subscript
+                    (ranged_attached_modifier (underline))
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (subscript
+                    (ranged_attached_modifier (spoiler))
+                )
+            )
+        )
+        (paragraph_segment
+            (ranged_attached_modifier
+                (subscript
+                    (ranged_attached_modifier (superscript))
+                )
+            )
+        )
+    )
+)
+
+============
+Deep Nesting
+============
+|*Bold /italic _underlined -struck through-_/*|
+---
+(document
+    (paragraph
+        (paragraph_segment
+            (ranged_attached_modifier
+                (bold
+                    (italic
+                        (underline
+                            (strikethrough)
+                        )
+                    )
+                )
+            )
+        )
+    )
+)
+
+=======================================
+No nested markup inside ranged verbatim
+=======================================
+|`*not bold*`|
+|`/not italic/`|
+|`-not struck through-`|
+|`_not underlined_`|
+|`!not spoiler!`|
+|`^not superscripted^`|
+|`,not subscripted,`|
+|`+not inline comment+`|
+|`$not inline math$`|
+|`=not variable=`|
+|`no:*link modifier*`|
+|`hidden \*escaped char`|
+|`|*not ranged bold*|`|
+|`|/not ranged italic/|`|
+|`|-not ranged struck through-|`|
+|`|_not ranged underlined_|`|
+|`|!not ranged spoiler!|`|
+|`|^not ranged superscripted^|`|
+|`|,not ranged subscripted,|`|
+|`|+not ranged inline comment+|`|
+|`|$not ranged inline math$|`|
+|`|=not ranged variable=|`|
+---
+(document
+    (paragraph
+        (paragraph_segment
+            (ranged_attached_modifier (verbatim))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (verbatim))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (verbatim))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (verbatim))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (verbatim))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (verbatim))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (verbatim))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (verbatim))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (verbatim))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (verbatim))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (verbatim))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (verbatim))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (verbatim))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (verbatim))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (verbatim))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (verbatim))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (verbatim))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (verbatim))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (verbatim))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (verbatim))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (verbatim))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (verbatim))
+        )
+    )
+)
+
+=============================================
+No nested markup inside ranged inline comment
+=============================================
+|+*not bold*+|
+|+/not italic/+|
+|+-not struck through-+|
+|+_not underlined_+|
+|+!not spoiler!+|
+|+^not superscripted^+|
+|+,not subscripted,+|
+|+`not verbatim`+|
+|+$not inline math$+|
+|+=not variable=+|
+|+no:*link modifier*+|
+|+hidden \*escaped char+|
+|+|*not ranged bold*|+|
+|+|/not ranged italic/|+|
+|+|-not ranged struck through-|+|
+|+|_not ranged underlined_|+|
+|+|!not ranged spoiler!|+|
+|+|^not ranged superscripted^|+|
+|+|,not ranged subscripted,|+|
+|+|`not ranged verbatim`|+|
+|+|$not ranged inline math$|+|
+|+|=not ranged variable=|+|
+---
+(document
+    (paragraph
+        (paragraph_segment
+            (ranged_attached_modifier (inline_comment))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_comment))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_comment))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_comment))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_comment))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_comment))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_comment))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_comment))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_comment))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_comment))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_comment))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_comment))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_comment))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_comment))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_comment))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_comment))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_comment))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_comment))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_comment))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_comment))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_comment))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_comment))
+        )
+    )
+)
+
+==========================================
+No nested markup inside ranged inline math
+==========================================
+|$*not bold*$|
+|$/not italic/$|
+|$-not struck through-$|
+|$_not underlined_$|
+|$!not spoiler!$|
+|$^not superscripted^$|
+|$,not subscripted,$|
+|$`not verbatim`$|
+|$+not inline comment+$|
+|$=not variable=$|
+|$no:*link modifier*$|
+|$hidden \*escaped char$|
+|$|*not ranged bold*|$|
+|$|/not ranged italic/|$|
+|$|-not ranged struck through-|$|
+|$|_not ranged underlined_|$|
+|$|!not ranged spoiler!|$|
+|$|^not ranged superscripted^|$|
+|$|,not ranged subscripted,|$|
+|$|`not ranged verbatim`|$|
+|$|+not ranged inline comment+|$|
+|$|=not ranged variable=|$|
+---
+(document
+    (paragraph
+        (paragraph_segment
+            (ranged_attached_modifier (inline_math))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_math))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_math))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_math))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_math))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_math))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_math))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_math))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_math))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_math))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_math))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_math))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_math))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_math))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_math))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_math))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_math))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_math))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_math))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_math))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_math))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (inline_math))
+        )
+    )
+)
+
+=======================================
+No nested markup inside ranged variable
+=======================================
+|=*not bold*=|
+|=/not italic/=|
+|=-not struck through-=|
+|=_not underlined_=|
+|=!no spoiler!=|
+|=^not superscripted^=|
+|=,not subscripted,=|
+|=`no verbatim`=|
+|=+no inline comment+=|
+|=$no inline math$=|
+|=no:*link modifier*=|
+|=hidden \*escaped char=|
+|=|*not ranged bold*|=|
+|=|/not ranged italic/|=|
+|=|-not ranged struck through-|=|
+|=|_not ranged underlined_|=|
+|=|!not ranged spoiler!|=|
+|=|^not ranged superscripted^|=|
+|=|,not ranged subscripted,|=|
+|=|`not ranged verbatim`|=|
+|=|+not ranged inline comment+|=|
+|=|$not ranged inline math$|=|
+---
+(document
+    (paragraph
+        (paragraph_segment
+            (ranged_attached_modifier (variable))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (variable))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (variable))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (variable))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (variable))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (variable))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (variable))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (variable))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (variable))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (variable))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (variable))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (variable))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (variable))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (variable))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (variable))
+        )
+        (paragraph_segment
+            (ranged_attached_modifier (variable))
+        )
         (paragraph_segment
             (ranged_attached_modifier (variable))
         )

--- a/test/corpus/ranged_markup.txt
+++ b/test/corpus/ranged_markup.txt
@@ -10,9 +10,13 @@ bold *| markup.
 Here is some |* ranged
 
 bold *| markup.
+|* Extend as *far* as possible *|
 ---
 (document
     (paragraph
+        (paragraph_segment
+            (ranged_attached_modifier (bold))
+        )
         (paragraph_segment
             (ranged_attached_modifier (bold))
         )
@@ -46,9 +50,13 @@ italic /| markup.
 Here is some |/ ranged
 
 italic /| markup.
+|/ Extend as /far/ as possible /|
 ---
 (document
     (paragraph
+        (paragraph_segment
+            (ranged_attached_modifier (italic))
+        )
         (paragraph_segment
             (ranged_attached_modifier (italic))
         )
@@ -82,9 +90,13 @@ strikethrough -| markup.
 Here is some |- ranged
 
 strikethrough -| markup.
+|- Extend as -far- as possible -|
 ---
 (document
     (paragraph
+        (paragraph_segment
+            (ranged_attached_modifier (strikethrough))
+        )
         (paragraph_segment
             (ranged_attached_modifier (strikethrough))
         )
@@ -118,9 +130,13 @@ underline _| markup.
 Here is some |_ ranged
 
 underline _| markup.
+|_ Extend as _far_ as possible _|
 ---
 (document
     (paragraph
+        (paragraph_segment
+            (ranged_attached_modifier (underline))
+        )
         (paragraph_segment
             (ranged_attached_modifier (underline))
         )
@@ -154,9 +170,13 @@ spoiler !| markup.
 Here is some |! ranged
 
 spoiler !| markup.
+|! Extend as !far! as possible !|
 ---
 (document
     (paragraph
+        (paragraph_segment
+            (ranged_attached_modifier (spoiler))
+        )
         (paragraph_segment
             (ranged_attached_modifier (spoiler))
         )
@@ -190,9 +210,13 @@ superscript ^| markup.
 Here is some |^ ranged
 
 superscript ^| markup.
+|^ Extend as ^far^ as possible ^|
 ---
 (document
     (paragraph
+        (paragraph_segment
+            (ranged_attached_modifier (superscript))
+        )
         (paragraph_segment
             (ranged_attached_modifier (superscript))
         )
@@ -226,9 +250,13 @@ subscript ,| markup.
 Here is some |, ranged
 
 subscript ,| markup.
+|, Extend as ,far, as possible ,|
 ---
 (document
     (paragraph
+        (paragraph_segment
+            (ranged_attached_modifier (subscript))
+        )
         (paragraph_segment
             (ranged_attached_modifier (subscript))
         )
@@ -262,9 +290,13 @@ verbatim `| markup.
 Here is some |` ranged
 
 verbatim `| markup.
+|` Extend as `far` as possible `|
 ---
 (document
     (paragraph
+        (paragraph_segment
+            (ranged_attached_modifier (verbatim))
+        )
         (paragraph_segment
             (ranged_attached_modifier (verbatim))
         )
@@ -298,9 +330,13 @@ inline_comment +| markup.
 Here is some |+ ranged
 
 inline_comment +| markup.
+|+ Extend as +far+ as possible +|
 ---
 (document
     (paragraph
+        (paragraph_segment
+            (ranged_attached_modifier (inline_comment))
+        )
         (paragraph_segment
             (ranged_attached_modifier (inline_comment))
         )
@@ -334,9 +370,13 @@ inline_math $| markup.
 Here is some |$ ranged
 
 inline_math $| markup.
+|$ Extend as $far$ as possible $|
 ---
 (document
     (paragraph
+        (paragraph_segment
+            (ranged_attached_modifier (inline_math))
+        )
         (paragraph_segment
             (ranged_attached_modifier (inline_math))
         )
@@ -370,9 +410,13 @@ variable =| markup.
 Here is some |= ranged
 
 variable =| markup.
+|= Extend as =far= as possible =|
 ---
 (document
     (paragraph
+        (paragraph_segment
+            (ranged_attached_modifier (variable))
+        )
         (paragraph_segment
             (ranged_attached_modifier (variable))
         )

--- a/test/corpus/ranged_markup.txt
+++ b/test/corpus/ranged_markup.txt
@@ -1,0 +1,396 @@
+===========
+Ranged Bold
+===========
+Here is some |*ranged bold*| markup.
+Here is some |* ranged bold*| markup.
+Here is some |*ranged bold *| markup.
+Here is some |* ranged bold *| markup.
+Here is some |* ranged
+bold *| markup.
+Here is some |* ranged
+
+bold *| markup.
+---
+(document
+    (paragraph
+        (paragraph_segment
+            (ranged_bold)
+        )
+        (paragraph_segment
+            (ranged_bold)
+        )
+        (paragraph_segment
+            (ranged_bold)
+        )
+        (paragraph_segment
+            (ranged_bold)
+        )
+        (paragraph_segment
+            (ranged_bold)
+        )
+        (paragraph_segment
+            (ranged_bold)
+        )
+    )
+)
+
+===========
+Ranged Italic
+===========
+Here is some |/ranged italic/| markup.
+Here is some |/ ranged italic/| markup.
+Here is some |/ranged italic /| markup.
+Here is some |/ ranged italic /| markup.
+Here is some |/ ranged
+italic /| markup.
+Here is some |/ ranged
+
+italic /| markup.
+---
+(document
+    (paragraph
+        (paragraph_segment
+            (ranged_italic)
+        )
+        (paragraph_segment
+            (ranged_italic)
+        )
+        (paragraph_segment
+            (ranged_italic)
+        )
+        (paragraph_segment
+            (ranged_italic)
+        )
+        (paragraph_segment
+            (ranged_italic)
+        )
+        (paragraph_segment
+            (ranged_italic)
+        )
+    )
+)
+
+===========
+Ranged Strikethrough
+===========
+Here is some |-ranged strikethrough-| markup.
+Here is some |- ranged strikethrough-| markup.
+Here is some |-ranged strikethrough -| markup.
+Here is some |- ranged strikethrough -| markup.
+Here is some |- ranged
+strikethrough -| markup.
+Here is some |- ranged
+
+strikethrough -| markup.
+---
+(document
+    (paragraph
+        (paragraph_segment
+            (ranged_strikethrough)
+        )
+        (paragraph_segment
+            (ranged_strikethrough)
+        )
+        (paragraph_segment
+            (ranged_strikethrough)
+        )
+        (paragraph_segment
+            (ranged_strikethrough)
+        )
+        (paragraph_segment
+            (ranged_strikethrough)
+        )
+        (paragraph_segment
+            (ranged_strikethrough)
+        )
+    )
+)
+
+===========
+Ranged Underline
+===========
+Here is some |_ranged underline_| markup.
+Here is some |_ ranged underline_| markup.
+Here is some |_ranged underline _| markup.
+Here is some |_ ranged underline _| markup.
+Here is some |_ ranged
+underline _| markup.
+Here is some |_ ranged
+
+underline _| markup.
+---
+(document
+    (paragraph
+        (paragraph_segment
+            (ranged_underline)
+        )
+        (paragraph_segment
+            (ranged_underline)
+        )
+        (paragraph_segment
+            (ranged_underline)
+        )
+        (paragraph_segment
+            (ranged_underline)
+        )
+        (paragraph_segment
+            (ranged_underline)
+        )
+        (paragraph_segment
+            (ranged_underline)
+        )
+    )
+)
+
+===========
+Ranged Spoiler
+===========
+Here is some |!ranged spoiler!| markup.
+Here is some |! ranged spoiler!| markup.
+Here is some |!ranged spoiler !| markup.
+Here is some |! ranged spoiler !| markup.
+Here is some |! ranged
+spoiler !| markup.
+Here is some |! ranged
+
+spoiler !| markup.
+---
+(document
+    (paragraph
+        (paragraph_segment
+            (ranged_spoiler)
+        )
+        (paragraph_segment
+            (ranged_spoiler)
+        )
+        (paragraph_segment
+            (ranged_spoiler)
+        )
+        (paragraph_segment
+            (ranged_spoiler)
+        )
+        (paragraph_segment
+            (ranged_spoiler)
+        )
+        (paragraph_segment
+            (ranged_spoiler)
+        )
+    )
+)
+
+===========
+Ranged Superscript
+===========
+Here is some |^ranged superscript^| markup.
+Here is some |^ ranged superscript^| markup.
+Here is some |^ranged superscript ^| markup.
+Here is some |^ ranged superscript ^| markup.
+Here is some |^ ranged
+superscript ^| markup.
+Here is some |^ ranged
+
+superscript ^| markup.
+---
+(document
+    (paragraph
+        (paragraph_segment
+            (ranged_superscript)
+        )
+        (paragraph_segment
+            (ranged_superscript)
+        )
+        (paragraph_segment
+            (ranged_superscript)
+        )
+        (paragraph_segment
+            (ranged_superscript)
+        )
+        (paragraph_segment
+            (ranged_superscript)
+        )
+        (paragraph_segment
+            (ranged_superscript)
+        )
+    )
+)
+
+===========
+Ranged Subscript
+===========
+Here is some |,ranged subscript,| markup.
+Here is some |, ranged subscript,| markup.
+Here is some |,ranged subscript ,| markup.
+Here is some |, ranged subscript ,| markup.
+Here is some |, ranged
+subscript ,| markup.
+Here is some |, ranged
+
+subscript ,| markup.
+---
+(document
+    (paragraph
+        (paragraph_segment
+            (ranged_subscript)
+        )
+        (paragraph_segment
+            (ranged_subscript)
+        )
+        (paragraph_segment
+            (ranged_subscript)
+        )
+        (paragraph_segment
+            (ranged_subscript)
+        )
+        (paragraph_segment
+            (ranged_subscript)
+        )
+        (paragraph_segment
+            (ranged_subscript)
+        )
+    )
+)
+
+===========
+Ranged Verbatim
+===========
+Here is some |`ranged verbatim`| markup.
+Here is some |` ranged verbatim`| markup.
+Here is some |`ranged verbatim `| markup.
+Here is some |` ranged verbatim `| markup.
+Here is some |` ranged
+verbatim `| markup.
+Here is some |` ranged
+
+verbatim `| markup.
+---
+(document
+    (paragraph
+        (paragraph_segment
+            (ranged_verbatim)
+        )
+        (paragraph_segment
+            (ranged_verbatim)
+        )
+        (paragraph_segment
+            (ranged_verbatim)
+        )
+        (paragraph_segment
+            (ranged_verbatim)
+        )
+        (paragraph_segment
+            (ranged_verbatim)
+        )
+        (paragraph_segment
+            (ranged_verbatim)
+        )
+    )
+)
+
+===========
+Ranged Inline Comment
+===========
+Here is some |+ranged inline_comment+| markup.
+Here is some |+ ranged inline_comment+| markup.
+Here is some |+ranged inline_comment +| markup.
+Here is some |+ ranged inline_comment +| markup.
+Here is some |+ ranged
+inline_comment +| markup.
+Here is some |+ ranged
+
+inline_comment +| markup.
+---
+(document
+    (paragraph
+        (paragraph_segment
+            (ranged_inline_comment)
+        )
+        (paragraph_segment
+            (ranged_inline_comment)
+        )
+        (paragraph_segment
+            (ranged_inline_comment)
+        )
+        (paragraph_segment
+            (ranged_inline_comment)
+        )
+        (paragraph_segment
+            (ranged_inline_comment)
+        )
+        (paragraph_segment
+            (ranged_inline_comment)
+        )
+    )
+)
+
+===========
+Ranged Inline Math
+===========
+Here is some |$ranged inline_math$| markup.
+Here is some |$ ranged inline_math$| markup.
+Here is some |$ranged inline_math $| markup.
+Here is some |$ ranged inline_math $| markup.
+Here is some |$ ranged
+inline_math $| markup.
+Here is some |$ ranged
+
+inline_math $| markup.
+---
+(document
+    (paragraph
+        (paragraph_segment
+            (ranged_inline_math)
+        )
+        (paragraph_segment
+            (ranged_inline_math)
+        )
+        (paragraph_segment
+            (ranged_inline_math)
+        )
+        (paragraph_segment
+            (ranged_inline_math)
+        )
+        (paragraph_segment
+            (ranged_inline_math)
+        )
+        (paragraph_segment
+            (ranged_inline_math)
+        )
+    )
+)
+
+===========
+Ranged Variable
+===========
+Here is some |=ranged variable=| markup.
+Here is some |= ranged variable=| markup.
+Here is some |=ranged variable =| markup.
+Here is some |= ranged variable =| markup.
+Here is some |= ranged
+variable =| markup.
+Here is some |= ranged
+
+variable =| markup.
+---
+(document
+    (paragraph
+        (paragraph_segment
+            (ranged_variable)
+        )
+        (paragraph_segment
+            (ranged_variable)
+        )
+        (paragraph_segment
+            (ranged_variable)
+        )
+        (paragraph_segment
+            (ranged_variable)
+        )
+        (paragraph_segment
+            (ranged_variable)
+        )
+        (paragraph_segment
+            (ranged_variable)
+        )
+    )
+)
+

--- a/test/corpus/tags.txt
+++ b/test/corpus/tags.txt
@@ -120,7 +120,7 @@ Lol
         (quote
             (quote1
                 (quote1_prefix)
-                (paragraph_segment)
+                (paragraph (paragraph_segment))
             )
         )
     )


### PR DESCRIPTION
Adds the ranged element syntax discussed on Discord.

- [x] change spoiler syntax from `|` to `!`
- [x] implement ranged attached modifiers
```norg
You can now use the range-modifier `|` to write |*ranged markup like this
which has the benefit

of allowing arbitrary whitespace inside of it      *|.

Ranged markup elements are placed into the paragraph in which they start.
They can contain other in-line syntax like more markup, links, etc.
No detached modifiers, headings, etc. are allowed inside of them.
```
- [x] support things like `|*/ ranged bold + italic /*|`
- [x] implement general ranged element frames
```norg
- |
  If you want to include more elements inside of a single detached modifier you can use a `||` ranged element.
  This allows you to for example include code blocks inside list items:

  @code lua
  print("Hello world!")
  @end
  ---
```