### PR TITLE
Define outputs for each system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ Cargo.lock
 package-lock.json
 yarn.lock
 *.log
-result/
+result

--- a/flake.nix
+++ b/flake.nix
@@ -8,24 +8,25 @@
     };
   };
   outputs = { self, nixpkgs, flake-utils, ... }@inputs:
-    let
-      defaultPackage = pkgs: pkgs.callPackage (nixpkgs + "/pkgs/development/tools/parsing/tree-sitter/grammar.nix") { } {
-        language = "norg";
-        source = ./.;
-        inherit (pkgs.tree-sitter) version;
-      };
-    in
-    (flake-utils.lib.eachDefaultSystem
-      (system:
-        let pkgs = import nixpkgs { inherit system; }; in
-        {
-          defaultPackage = defaultPackage pkgs;
-          devShell = pkgs.mkShell {
-            nativeBuildInputs = with pkgs; [
-              nodejs
-              nodePackages.node-gyp
-              tree-sitter
-            ];
-          };
-        })) // (let pkgs = import nixpkgs { }; in { defaultPackage = defaultPackage pkgs; });
+    (flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        grammar = pkgs.callPackage
+          "${nixpkgs}/pkgs/development/tools/parsing/tree-sitter/grammar.nix" { };
+      in rec {
+        packages.tree-sitter-norg = grammar {
+          language = "norg";
+          source = ./.;
+          inherit (pkgs.tree-sitter) version;
+        };
+        defaultPackage = packages.tree-sitter-norg;
+        devShell = pkgs.mkShell {
+          nativeBuildInputs = with pkgs; [
+            python3
+            nodejs
+            nodePackages.node-gyp
+            tree-sitter
+          ];
+        };
+      }));
 }


### PR DESCRIPTION
Follow-up from https://github.com/nvim-neorg/nixpkgs-neorg-overlay/issues/1#issuecomment-1266974818.

I realized it basically undoes https://github.com/nvim-neorg/tree-sitter-norg/commit/ed37d4c571104c64e233a319fc366ede75ee56d4. By merging in defaultPackage again, it would remove e.g. defaultPackage.x86_64-linux which is what is blocking me.
What was the reasoning for that change? I don't think, in flakes parlance, there can't be a "generic" package as the result is system-dependant.

That said, users shouldn't have too much exposure to the `system` -- `nix build .`, `nix develop .`, etc. should "just work" unless you intend to cross compile, or compile with emulation[^1].

If that's alright, I have corresponding changes for tree-sitter-norg-{meta,table}.

[^1]
What I'm doing for aarch64-linux is having the following nixos config...

```nix
  boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
```

...so that I can say:
```sh
  $ nix build .#packages.aarch64-linux.tree-sitter-norg
  $ file result/parser
  result/parser: ELF 64-bit LSB shared object, ARM aarch64, version 1 (SYSV), dynamically linked, stripped
```
