### PR TITLE
refactor: optimize storing and restoring Scanner

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -7,6 +7,7 @@
 #include <regex>
 #include <string>
 #include <unordered_map>
+#include <cstring>
 
 #include "tree_sitter/parser.h"
 
@@ -969,11 +970,8 @@ extern "C"
         buffer[0] = last_token;
         buffer[1] = tag_level;
 
-        // Store `current` (which is an int32_t) in a char array by splitting it up
-        buffer[2] = current & 0xFF;
-        buffer[3] = (current >> 8) & 0xFF;
-        buffer[4] = (current >> 16) & 0xFF;
-        buffer[5] = (current >> 24) & 0xFF;
+        // Copy 4 bytes from int32_t to buffer 2 to 6 positions.
+        std::memcpy(buffer + 2, &current, 4);
 
         // Serialize the attached modifier bitset into the char array
         // We cast it down to a uint32_t because we genuinely won't be using any
@@ -1004,8 +1002,8 @@ extern "C"
 
         last_token = (TokenType)buffer[0];
         tag_level = (size_t)buffer[1];
-        current = (uint32_t)buffer[5] << 24 | (uint32_t)buffer[4] << 16 | (uint32_t)buffer[3] << 8 |
-                  (uint32_t)buffer[2];
+
+        std::memcpy(&current, buffer + 2, 4);
 
         for (int i = 0; i < active_modifiers.size(); i++)
             active_modifiers[i] = buffer[6 + i];


### PR DESCRIPTION
Use C memcpy function to copy raw bytes.