### PR TITLE
Refactor external scanner

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -1,15 +1,16 @@
 #include <algorithm>
 #include <array>
 #include <bitset>
+#include <cstring>
 #include <cwctype>
 #include <iostream>
 #include <locale>
 #include <regex>
 #include <string>
 #include <unordered_map>
-#include <cstring>
-
 #include "tree_sitter/parser.h"
+
+using namespace std;
 
 enum TokenType : char
 {
@@ -183,48 +184,89 @@ enum class TagType : char
     IN_VERBATIM_TAG,
 };
 
-// Operator overloads for TokenTypes (allows for their chaining)
 namespace
 {
-std::vector<TokenType> operator|(TokenType lhs, TokenType rhs)
-{
-    return std::vector<TokenType>({lhs, static_cast<TokenType>(rhs)});
-}
-
-std::vector<TokenType>&& operator|(std::vector<TokenType>&& lhs, TokenType rhs)
-{
-    lhs.push_back(rhs);
-    return std::move(lhs);
-}
-}  // namespace
 
 template <typename Type>
-std::ostream& operator<<(std::ostream& stream, const std::vector<Type>& vec)
+ostream& operator<<(ostream& stream, const vector<Type>& vec)
 {
     stream << '{';
-
     for (auto& elem : vec)
-    {
         stream << elem << ",";
-    }
-
-    return stream << '}';
+    stream << '}';
+    return stream;
 }
 
 template <typename First, typename Second>
-std::ostream& operator<<(std::ostream& stream, const std::pair<First, Second>& pair)
+ostream& operator<<(ostream& stream, const pair<First, Second>& pair)
 {
     return stream << '(' << (char)pair.first << ", " << (int)pair.second << ')';
 }
 
-class Scanner
+}  // namespace
+
+struct Scanner
 {
-   public:
-    bool scan(TSLexer* lexer, const bool* valid_symbols)
+    TSLexer* lexer;
+
+    int32_t
+    m_Previous = 0,  // previous char
+    m_Current = 0;   // current char
+
+    TagType m_TagContext = TagType::NONE;
+    size_t m_TagLevel = 0;
+
+    bool m_InLinkLocation = false;
+
+    // The last matched token type (used to detect things like todo items
+    // which require an unordered list prefix beforehand)
+    TokenType m_LastToken = NONE;
+
+    // Used for lookback
+    size_t m_ParsedChars = 0;
+
+    const array<int32_t, 12> m_DetachedModifiers = {
+        '*',  // Headings
+        '-',  // Unordered Lists
+        '>',  // Quotes
+        '%',  // Attributes
+        '=',
+        '~',  // Ordered Lists
+        '$',  // Definitions
+        '_',
+        '^',  // Footnotes
+        '&',
+        '<',
+        ':',  // Table cells
+    };
+
+    const unordered_map<int32_t, TokenType> m_DetachedModifierExtensions = {
+        {'#', PRIORITY},
+        {'@', TIMESTAMP},
+        {' ', TODO_ITEM_UNDONE},
+        {'-', TODO_ITEM_PENDING},
+        {'x', TODO_ITEM_DONE},
+        {'=', TODO_ITEM_ON_HOLD},
+        {'_', TODO_ITEM_CANCELLED},
+        {'!', TODO_ITEM_URGENT},
+        {'+', TODO_ITEM_RECURRING},
+        {'?', TODO_ITEM_UNCERTAIN},
+    };
+
+    const unordered_map<int32_t, TokenType> m_AttachedModifiers = {
+        {'*', BOLD_OPEN},        {'/', ITALIC_OPEN},       {'-', STRIKETHROUGH_OPEN},
+        {'_', UNDERLINE_OPEN},   {'!', SPOILER_OPEN},      {'`', VERBATIM_OPEN},
+        {'^', SUPERSCRIPT_OPEN}, {',', SUBSCRIPT_OPEN},    {'%', INLINE_COMMENT_OPEN},
+        {'$', INLINE_MATH_OPEN}, {'&', INLINE_MACRO_OPEN},
+    };
+
+    bitset<((INLINE_MACRO_OPEN - BOLD_OPEN) / 2) + 1> m_ActiveModifiers;
+
+    bool scan(const bool* valid_symbols)
     {
         lexer->result_symbol = NONE;
 
-        // Are we at the end of file? If so, bail
+        // Are we at the end of file? If so, bail.
         if (lexer->eof(lexer) || !lexer->lookahead)
         {
             reset_active_modifiers();
@@ -233,12 +275,12 @@ class Scanner
 
         if (m_LastToken == TRAILING_MODIFIER)
         {
-            advance(lexer);
-            return parse_text(lexer);
+            advance();
+            return parse_text();
         }
         else if (is_newline(lexer->lookahead))
         {
-            advance(lexer);
+            advance();
 
             lexer->result_symbol = m_LastToken = LINE_BREAK;
 
@@ -256,7 +298,7 @@ class Scanner
 
             if (is_newline(lexer->lookahead))
             {
-                advance(lexer);
+                advance();
                 lexer->result_symbol = m_LastToken = PARAGRAPH_BREAK;
                 reset_active_modifiers();
             }
@@ -268,55 +310,41 @@ class Scanner
         if (lexer->get_column(lexer) == 0)
         {
             // Skip all leading whitespace
-            while (std::iswblank(lexer->lookahead))
-                skip(lexer);
+            while (is_blank(lexer->lookahead))
+                skip();
 
-            // We are dealing with a ranged verbatim tag (@something)
+            // We are dealing with a ranged verbatim tag: @something
             if (lexer->lookahead == '@')
             {
-                advance(lexer);
+                advance();
 
                 // Mark the end of the token here
                 // We do this because we only want the returned token to be part
                 // of the `@` symbol, not the symbol + the name
                 lexer->mark_end(lexer);
 
-                // These sets of checks check whether the tag is `@end`
-                if (lexer->lookahead == 'e')
+                // Check whether the tag is `@end`.
+                if (token("end") && (iswspace(lexer->lookahead) || !lexer->lookahead))
                 {
-                    advance(lexer);
-                    if (lexer->lookahead == 'n')
+                    while (is_blank(lexer->lookahead))
+                        advance();
+
+                    if ((iswspace(lexer->lookahead) || !lexer->lookahead)
+                        && m_TagContext == TagType::IN_VERBATIM_TAG)
                     {
-                        advance(lexer);
-                        if (lexer->lookahead == 'd')
-                        {
-                            advance(lexer);
-                            if (!lexer->lookahead || std::iswspace(lexer->lookahead))
-                            {
-                                while (std::iswspace(lexer->lookahead) &&
-                                       !is_newline(lexer->lookahead) && lexer->lookahead)
-                                    advance(lexer);
-
-                                if ((!lexer->lookahead || std::iswspace(lexer->lookahead)) &&
-                                    m_TagContext == TagType::IN_VERBATIM_TAG)
-                                {
-                                    lexer->result_symbol = m_LastToken = RANGED_VERBATIM_TAG_END;
-                                    m_TagContext = TagType::NONE;
-                                    return true;
-                                }
-
-                                lexer->result_symbol = m_LastToken = WORD;
-                                return true;
-                            }
-                        }
+                        lexer->result_symbol = m_LastToken = RANGED_VERBATIM_TAG_END;
+                        m_TagContext = TagType::NONE;
+                        return true;
                     }
+
+                    lexer->result_symbol = m_LastToken = WORD;
+                    return true;
                 }
 
-                // This is a fallback. If the tag ends up not being `@end`
-                // then...
+                // This is a fallback. If the tag ends up not being `@end` then...
                 if (m_LastToken == RANGED_VERBATIM_TAG || m_TagContext == TagType::IN_VERBATIM_TAG)
                 {
-                    // ignore the char if we are already inside of a ranged tag.
+                    // Ignore the char if we are already inside of a ranged tag.
                     lexer->result_symbol = m_LastToken = WORD;
                     return true;
                 }
@@ -327,12 +355,12 @@ class Scanner
             }
 
             if (m_TagContext == TagType::IN_VERBATIM_TAG)
-                return parse_text(lexer);
+                return parse_text();
 
             // We are dealing with a macro tag (=something)
             if (lexer->lookahead == '=' && m_TagContext != TagType::IN_VERBATIM_TAG)
             {
-                advance(lexer);
+                advance();
 
                 // Mark the end of the token here
                 // We do this because we only want the returned token to be part
@@ -340,50 +368,37 @@ class Scanner
                 lexer->mark_end(lexer);
 
                 // These sets of checks check whether the tag is `=end`
-                if (lexer->lookahead == 'e')
+                if (token("end") && (iswspace(lexer->lookahead) || !lexer->lookahead))
                 {
-                    advance(lexer);
-                    if (lexer->lookahead == 'n')
+                    while (lexer->lookahead && iswspace(lexer->lookahead)
+                           && !is_newline(lexer->lookahead))
+                        advance();
+
+                    if ((iswspace(lexer->lookahead) || !lexer->lookahead) && m_TagLevel)
                     {
-                        advance(lexer);
-                        if (lexer->lookahead == 'd')
-                        {
-                            advance(lexer);
-                            if (!lexer->lookahead || std::iswspace(lexer->lookahead))
-                            {
-                                while (std::iswspace(lexer->lookahead) &&
-                                       !is_newline(lexer->lookahead) && lexer->lookahead)
-                                    advance(lexer);
-
-                                if ((!lexer->lookahead || std::iswspace(lexer->lookahead)) &&
-                                    m_TagLevel)
-                                {
-                                    lexer->result_symbol = m_LastToken = MACRO_TAG_END;
-                                    --m_TagLevel;
-                                    return true;
-                                }
-
-                                lexer->result_symbol = m_LastToken = WORD;
-                                return true;
-                            }
-                        }
+                        lexer->result_symbol = m_LastToken = MACRO_TAG_END;
+                        --m_TagLevel;
+                        return true;
                     }
+
+                    lexer->result_symbol = m_LastToken = WORD;
+                    return true;
                 }
                 else if (lexer->lookahead == '=')
                 {
-                    advance(lexer);
+                    advance();
                     if (lexer->lookahead == '=')
                     {
                         // we are now three-characters in
                         do
-                            advance(lexer);
+                            advance();
                         while (lexer->lookahead == '=');
 
                         if (is_newline(lexer->lookahead))
                         {
                             // reset the marked end
                             lexer->mark_end(lexer);
-                            advance(lexer);
+                            advance();
                             lexer->result_symbol = m_LastToken = STRONG_PARAGRAPH_DELIMITER;
                             return true;
                         }
@@ -391,18 +406,17 @@ class Scanner
                         {
                             // reset the marked end
                             lexer->mark_end(lexer);
-                            advance(lexer);
+                            advance();
                             lexer->result_symbol = m_LastToken = WORD;
                             return true;
                         }
                     }
                 }
 
-                // This is a fallback. If the tag ends up not being `=end`
-                // then...
+                // This is a fallback. If the tag ends up not being `=end` then...
                 if (m_LastToken == MACRO_TAG)
                 {
-                    // ignore the char if we are already inside of a ranged tag.
+                    // Ignore the char if we are already inside of a ranged tag.
                     lexer->result_symbol = m_LastToken = WORD;
                     return true;
                 }
@@ -416,54 +430,39 @@ class Scanner
             // We are dealing with a ranged tag (|something)
             else if (lexer->lookahead == '|' && m_TagContext != TagType::IN_VERBATIM_TAG)
             {
-                advance(lexer);
+                advance();
 
-                // Mark the end of the token here
+                // Mark the end of the token here.
                 // We do this because we only want the returned token to be part
-                // of the `|` symbol, not the symbol + the name
+                // of the `|` symbol, not the symbol + the name.
                 lexer->mark_end(lexer);
 
-                // These sets of checks check whether the tag is `|end`
-                if (lexer->lookahead == 'e')
+                // These sets of checks check whether the tag is `|end`.
+                if (token("end") && (iswspace(lexer->lookahead) || !lexer->lookahead))
                 {
-                    advance(lexer);
-                    if (lexer->lookahead == 'n')
+                    while (is_blank(lexer->lookahead))
+                        advance();
+
+                    if ((iswspace(lexer->lookahead) || !lexer->lookahead) && m_TagLevel)
                     {
-                        advance(lexer);
-                        if (lexer->lookahead == 'd')
-                        {
-                            advance(lexer);
-                            if (!lexer->lookahead || std::iswspace(lexer->lookahead))
-                            {
-                                while (std::iswspace(lexer->lookahead) &&
-                                       !is_newline(lexer->lookahead) && lexer->lookahead)
-                                    advance(lexer);
-
-                                if ((!lexer->lookahead || std::iswspace(lexer->lookahead)) &&
-                                    m_TagLevel)
-                                {
-                                    lexer->result_symbol = m_LastToken = RANGED_TAG_END;
-                                    --m_TagLevel;
-                                    return true;
-                                }
-
-                                lexer->result_symbol = m_LastToken = WORD;
-                                return true;
-                            }
-                        }
+                        lexer->result_symbol = m_LastToken = RANGED_TAG_END;
+                        --m_TagLevel;
+                        return true;
                     }
-                }
 
-                // This is a fallback. If the tag ends up not being `|end`
-                // then...
-                if (m_LastToken == RANGED_TAG)
-                {
-                    // ignore the char if we are already inside of a ranged tag.
                     lexer->result_symbol = m_LastToken = WORD;
                     return true;
                 }
 
-                // or push back the indentation level and return.
+                // This is a fallback. If the tag ends up not being `|end` then...
+                if (m_LastToken == RANGED_TAG)
+                {
+                    // Ignore the char if we are already inside of a ranged tag.
+                    lexer->result_symbol = m_LastToken = WORD;
+                    return true;
+                }
+
+                // Or push back the indentation level and return.
                 lexer->result_symbol = m_LastToken = RANGED_TAG;
                 m_TagContext = TagType::ON_TAG;
                 ++m_TagLevel;
@@ -472,9 +471,9 @@ class Scanner
             // we are dealing with a strong carryover (#something)
             else if (lexer->lookahead == '#' && m_TagContext != TagType::IN_VERBATIM_TAG)
             {
-                advance(lexer);
+                advance();
 
-                if (!lexer->lookahead || std::iswspace(lexer->lookahead))
+                if (!lexer->lookahead || iswspace(lexer->lookahead))
                 {
                     if (is_newline(lexer->lookahead))
                         lexer->result_symbol = m_LastToken = INDENT_SEGMENT;
@@ -490,7 +489,7 @@ class Scanner
             // we are dealing with a weak carryover (+something)
             else if (lexer->lookahead == '+' && m_TagContext != TagType::IN_VERBATIM_TAG)
             {
-                advance(lexer);
+                advance();
                 if (lexer->lookahead != '+')
                 {
                     lexer->result_symbol = m_LastToken = WEAK_CARRYOVER;
@@ -500,7 +499,7 @@ class Scanner
             // we are dealing with a infirm tag (.something)
             else if (lexer->lookahead == '.' && m_TagContext != TagType::IN_VERBATIM_TAG)
             {
-                advance(lexer);
+                advance();
                 if (lexer->lookahead != '.')
                 {
                     lexer->result_symbol = m_LastToken = INFIRM_TAG;
@@ -517,24 +516,18 @@ class Scanner
             // always be chosen. This means that if we have 7 consecutive
             // '*' chars then we will still fall back to the HEADING6 token
             // instead.
-            if (check_detached(lexer,
-                               HEADING1 | HEADING2 | HEADING3 | HEADING4 | HEADING5 | HEADING6,
-                               {'*'}) != NONE)
+            if (check_detached({HEADING1, HEADING2, HEADING3,
+                                HEADING4, HEADING5, HEADING6}, '*'))
                 return true;
 
             // Check for the existence of quotes
-            if (check_detached(lexer, QUOTE1 | QUOTE2 | QUOTE3 | QUOTE4 | QUOTE5 | QUOTE6, {'>'}) !=
-                NONE)
+            if (check_detached({QUOTE1, QUOTE2, QUOTE3, QUOTE4, QUOTE5, QUOTE6}, '>'))
                 return true;
 
             // Check for the existence of an unordered list element.
-            if (check_detached(lexer,
-                               UNORDERED_LIST1 | UNORDERED_LIST2 | UNORDERED_LIST3 |
-                                   UNORDERED_LIST4 | UNORDERED_LIST5 | UNORDERED_LIST6,
-                               {'-'}) != NONE)
-            {
+            if (check_detached({UNORDERED_LIST1, UNORDERED_LIST2, UNORDERED_LIST3,
+                                UNORDERED_LIST4, UNORDERED_LIST5, UNORDERED_LIST6}, '-'))
                 return true;
-            }
             // If we end up failing to parse an unordered modifier not all
             // hope is lost. We also have a weak paragraph delimiter which
             // looks like this:
@@ -558,15 +551,13 @@ class Scanner
             //   ^ will be here, and lexer->lookahead will return '\n'
             else if (is_newline(lexer->lookahead) && m_ParsedChars >= 3)
             {
-                advance(lexer);
+                advance();
                 lexer->result_symbol = m_LastToken = WEAK_PARAGRAPH_DELIMITER;
                 return true;
             }
 
-            if (check_detached(lexer,
-                               ORDERED_LIST1 | ORDERED_LIST2 | ORDERED_LIST3 | ORDERED_LIST4 |
-                                   ORDERED_LIST5 | ORDERED_LIST6,
-                               {'~'}) != NONE)
+            if (check_detached({ORDERED_LIST1, ORDERED_LIST2, ORDERED_LIST3,
+                                ORDERED_LIST4, ORDERED_LIST5, ORDERED_LIST6}, '~'))
                 return true;
             else if (is_newline(lexer->lookahead) && m_ParsedChars == 1)
             {
@@ -580,34 +571,34 @@ class Scanner
                 return true;
             }
 
-            if (check_detached(lexer, SINGLE_DEFINITION | MULTI_DEFINITION | NONE, {'$'}) != NONE)
+            if (check_detached({SINGLE_DEFINITION, MULTI_DEFINITION, NONE}, '$'))
                 return true;
             else if (is_newline(lexer->lookahead) && m_ParsedChars == 2)
             {
-                advance(lexer);
+                advance();
                 lexer->result_symbol = MULTI_DEFINITION_SUFFIX;
                 return true;
             }
 
-            if (check_detached(lexer, SINGLE_FOOTNOTE | MULTI_FOOTNOTE | NONE, {'^'}) != NONE)
+            if (check_detached({SINGLE_FOOTNOTE, MULTI_FOOTNOTE, NONE}, '^'))
                 return true;
             else if (is_newline(lexer->lookahead) && m_ParsedChars == 2)
             {
-                advance(lexer);
+                advance();
                 lexer->result_symbol = MULTI_FOOTNOTE_SUFFIX;
                 return true;
             }
 
-            if (check_detached(lexer, SINGLE_TABLE_CELL | MULTI_TABLE_CELL | NONE, {':'}) != NONE)
+            if (check_detached({SINGLE_TABLE_CELL, MULTI_TABLE_CELL, NONE}, ':'))
                 return true;
             else if (is_newline(lexer->lookahead) && m_ParsedChars == 2)
             {
-                advance(lexer);
+                advance();
                 lexer->result_symbol = MULTI_TABLE_CELL_SUFFIX;
                 return true;
             }
 
-            if (check_detached(lexer, NONE, {'_'}) != NONE)
+            if (check_detached({NONE, NONE}, '_'))
                 return true;
             else if (is_newline(lexer->lookahead) && m_ParsedChars >= 3)
             {
@@ -616,90 +607,89 @@ class Scanner
             }
         }
 
-        if (lexer->lookahead == '~')
-        {
-            advance(lexer);
+        switch (lexer->lookahead) {
+        case '~':
+            advance();
             lexer->mark_end(lexer);
 
             if (is_newline(lexer->lookahead))
             {
-                advance(lexer);
-
+                advance();
                 if (lexer->eof(lexer))
                 {
                     reset_active_modifiers();
                     return false;
                 }
-
                 lexer->result_symbol = m_LastToken = TRAILING_MODIFIER;
                 return true;
             }
 
-            return parse_text(lexer);
-        }
-        else if (lexer->lookahead == '\\')  // Check for an escape seqence (e.g. "\*")
-        {
-            advance(lexer);
+            return parse_text();
+        case '\\':  // Check for an escape seqence (e.g. "\*")
+            advance();
             lexer->result_symbol = m_LastToken = ESCAPE_SEQUENCE;
             return true;
         }
-        else if (check_detached_mod_extension(lexer))
+
+        if (check_detached_mod_extension())
             return true;
-        else if (((m_LastToken >= HEADING1 && m_LastToken <= MULTI_TABLE_CELL_SUFFIX) || m_LastToken == DETACHED_MODIFIER_EXTENSION_END) && lexer->lookahead == ':')
+        else if (((m_LastToken >= HEADING1 && m_LastToken <= MULTI_TABLE_CELL_SUFFIX)
+                  || m_LastToken == DETACHED_MODIFIER_EXTENSION_END)
+                 && lexer->lookahead == ':')
         {
-            advance(lexer);
+            advance();
             bool is_indent_segment = false;
 
             if (lexer->lookahead == ':')
             {
-                advance(lexer);
+                advance();
                 is_indent_segment = true;
             }
 
-            if (lexer->lookahead != '\r' && lexer->lookahead != '\n')
+            if (!is_newline(lexer->lookahead))
             {
                 lexer->result_symbol = m_LastToken = WORD;
                 return true;
             }
 
             // Move past the newline character as well
-            advance(lexer);
+            advance();
 
             lexer->result_symbol = m_LastToken = (TokenType)(SLIDE + is_indent_segment);
             return true;
         }
-        else if (lexer->lookahead == '<')
-        {
-            advance(lexer);
 
-            if (!std::iswspace(lexer->lookahead))
+        switch (lexer->lookahead) {
+        case '<':
+            advance();
+
+            if (!iswspace(lexer->lookahead))
             {
                 lexer->result_symbol = m_LastToken = INLINE_LINK_TARGET_OPEN;
                 m_InLinkLocation = true;
                 return true;
             }
-        }
-        else if (lexer->lookahead == '>')
-        {
-            advance(lexer);
+            break;
+        case '>':
+            advance();
 
-            if (!std::iswspace(m_Previous) && m_LastToken != LINK_LOCATION_BEGIN &&
-                m_LastToken != LINK_FILE_END)
+            if (!iswspace(m_Previous) && m_LastToken != LINK_LOCATION_BEGIN
+                && m_LastToken != LINK_FILE_END)
             {
                 lexer->result_symbol = m_LastToken = INLINE_LINK_TARGET_CLOSE;
                 m_InLinkLocation = false;
                 return true;
             }
-        }
-        else if (lexer->lookahead == '(')
-        {
-            advance(lexer);
+            break;
+        case '(':
+            advance();
 
-            if (!std::iswspace(lexer->lookahead) && m_LastToken != NONE &&
-                ((m_LastToken >= BOLD_OPEN && m_LastToken <= INLINE_MACRO_CLOSE &&
-                  (m_LastToken % 2) == (BOLD_CLOSE % 2)) ||
-                 m_LastToken == LINK_DESCRIPTION_END || m_LastToken == LINK_LOCATION_END ||
-                 m_LastToken == INLINE_LINK_TARGET_CLOSE))
+            if (!iswspace(lexer->lookahead) && m_LastToken != NONE
+                && ((m_LastToken >= BOLD_OPEN && m_LastToken <= INLINE_MACRO_CLOSE
+                     && (m_LastToken % 2) == (BOLD_CLOSE % 2))
+                    || m_LastToken == LINK_DESCRIPTION_END
+                    || m_LastToken == LINK_LOCATION_END
+                    || m_LastToken == INLINE_LINK_TARGET_CLOSE))
             {
                 lexer->result_symbol = m_LastToken = ATTACHED_MODIFIER_BEGIN;
                 return true;
@@ -709,307 +699,259 @@ class Scanner
                 lexer->result_symbol = m_LastToken = WORD;
                 return true;
             }
-        }
-        else if (lexer->lookahead == ')')
-        {
-            advance(lexer);
+            break;
+        case ')':
+            advance();
 
-            if (!std::iswspace(m_Previous))
+            if (!iswspace(m_Previous))
             {
                 lexer->result_symbol = m_LastToken = ATTACHED_MODIFIER_END;
                 return true;
             }
-        }
-        else if (lexer->lookahead == '[')
-        {
-            advance(lexer);
+            break;
+        case '[':
+            advance();
 
-            if (!std::iswspace(lexer->lookahead))
+            if (!iswspace(lexer->lookahead))
             {
                 lexer->result_symbol = m_LastToken = LINK_DESCRIPTION_BEGIN;
                 return true;
             }
-        }
-        else if (lexer->lookahead == ']')
-        {
-            advance(lexer);
+            break;
+        case ']':
+            advance();
 
-            if (!std::iswspace(m_Previous))
+            if (!iswspace(m_Previous))
             {
                 lexer->result_symbol = m_LastToken = LINK_DESCRIPTION_END;
                 return true;
             }
-        }
-        else if (lexer->lookahead == '{')
-        {
-            advance(lexer);
+            break;
+        case '{':
+            advance();
 
-            if (!std::iswspace(lexer->lookahead))
+            if (!iswspace(lexer->lookahead))
             {
                 lexer->result_symbol = m_LastToken = LINK_LOCATION_BEGIN;
                 m_InLinkLocation = true;
                 return true;
             }
-        }
-        else if (lexer->lookahead == '}')
-        {
-            advance(lexer);
+            break;
+        case '}':
+            advance();
 
-            if (m_Previous == '\n' || m_Previous == '\r')
+            if (is_newline(m_Previous))
             {
                 lexer->result_symbol = m_LastToken = NONE;
                 return true;
             }
 
-            if (!std::iswspace(m_Previous))
+            if (!iswspace(m_Previous))
             {
                 lexer->result_symbol = m_LastToken = LINK_LOCATION_END;
                 m_InLinkLocation = false;
                 return true;
             }
+            break;
         }
-        else if (m_InLinkLocation && check_link_location(lexer))
+
+        if (m_InLinkLocation && check_link_location())
             return true;
 
         // If we are not in a ranged tag then we should also check for potential
         // attached modifiers, like *this*.
-        if (check_attached(lexer) != NONE)
+        if (check_attached())
             return true;
 
         // Match paragraphs
-        return parse_text(lexer);
+        return parse_text();
     }
 
-    size_t& get_tag_level() noexcept { return m_TagLevel; }
-    TagType& get_tag_context() noexcept { return m_TagContext; }
-    bool& get_in_link_location() noexcept { return m_InLinkLocation; }
-    TokenType& get_last_token() noexcept { return m_LastToken; }
-    int32_t& get_current_char() noexcept { return m_Current; }
-    auto& get_active_modifiers() noexcept { return m_ActiveModifiers; }
-
-   private:
-    // Skips the next character without including it in the final result
-    void skip(TSLexer* lexer)
+    // Skips the next character without including it in the final result.
+    void skip()
     {
         m_Previous = m_Current;
         m_Current = lexer->lookahead;
-        return lexer->advance(lexer, true);
+        lexer->advance(lexer, true);
     }
 
     // Advances the lexer forward. The char that was advanced will be returned
-    // in the final result
-    void advance(TSLexer* lexer)
+    // in the final result.
+    void advance()
     {
         m_Previous = m_Current;
         m_Current = lexer->lookahead;
-        return lexer->advance(lexer, false);
+        lexer->advance(lexer, false);
     }
 
-    // An alternate implementation for `check_detached` in case you don't have a
-    // bunch of chained results
-    template <size_t Size = 1>
-    inline TokenType check_detached(TSLexer* lexer,
-                                    TokenType result,
-                                    const std::array<int32_t, Size>& expected,
-                                    std::pair<char, TokenType> terminate_at = {0, NONE})
+    bool token(string str)
     {
-        return check_detached(lexer, result | NONE, expected,
-                              {terminate_at.first, terminate_at.second | NONE});
-    }
-
-    /*
-     * Checks for the existence of a detached modifier
-     * @param lexer - a pointer to the treesitter lexer
-     * @param results - a list of potential results repending on the amount of
-     * consecutive matches found
-     * @param expected - a list of expected modifiers to appear in the sequence
-     */
-    template <size_t Size = 1>
-    [[nodiscard]] TokenType check_detached(TSLexer* lexer,
-                                           const std::vector<TokenType>& results,
-                                           const std::array<int32_t, Size>& expected,
-                                           std::pair<char, std::vector<TokenType>> terminate_at = {
-                                               0, NONE | NONE})
-    {
-        static_assert(Size > 0, "check_detached Size template must be greater than 0");
-
-        size_t i = m_ParsedChars = 0;
-
-        // Loop as long as the next character is a valid detached modifier
-        for (auto detached_modifier = std::find(m_DetachedModifiers.begin(),
-                                                m_DetachedModifiers.end(), lexer->lookahead);
-             detached_modifier != m_DetachedModifiers.end();
-             detached_modifier = std::find(m_DetachedModifiers.begin(), m_DetachedModifiers.end(),
-                                           lexer->lookahead),
-                  i++, m_ParsedChars++)
+        for (int32_t c : str)
         {
-            // If we've specified a termination character and we match then the
-            // token lexing prematurely
-            if (terminate_at.first != 0 && lexer->lookahead == terminate_at.first)
-            {
-                advance(lexer);
+            if (c == lexer->lookahead)
+                advance();
+            else
+                return false;
+        }
+        return true;
+    }
 
-                // Skip other potential whitespace
-                while (lexer->lookahead && (lexer->lookahead == ' ' || lexer->lookahead == '\t'))
-                    advance(lexer);
-
-                TokenType result =
-                    terminate_at.second[clamp(i, size_t {}, terminate_at.second.size()) - 1];
-
-                lexer->result_symbol = m_LastToken = result;
-
-                reset_active_modifiers();
-                return result;
-            }
-
-            // If the next character is not one we expect then break
-            // We use clamp() here to prevent overflow and to make the last
-            // element of the expected array the fallback
-            if (lexer->lookahead != expected[clamp(i, size_t {}, Size - 1)])
+    /**
+     * Checks for the existence of a detached modifier
+     * @param results - a list of potential results depending on the amount of consecutive matches
+     * found;
+     * @param expected - a list of expected modifiers to appear in the sequence.
+     */
+    [[nodiscard]]
+    bool check_detached(const vector<TokenType>& results, const int32_t expected)
+    {
+        size_t i = m_ParsedChars = 0;
+        auto detached_modifier = find(m_DetachedModifiers.begin(), m_DetachedModifiers.end(),
+                                      lexer->lookahead);
+        do {
+            // If the next character is not one we expect then break.
+            if (lexer->lookahead != expected)
                 break;
 
-            advance(lexer);
+            advance();
 
             // If the next character is whitespace (which is the distinguishing
-            // factor between an attached/detached modifier)
-            if (std::iswspace(lexer->lookahead) && (!is_newline(lexer->lookahead)))
+            // factor between an attached/detached modifier).
+            if (is_blank(lexer->lookahead))
             {
                 // Retrieve the correct result from the list of provided results
-                // depending on how many characters were matched. If we've
-                // exceeded the number of results then the clamp function will
-                // fall back to the last element
-                TokenType result = results[clamp(i, size_t {}, results.size() - 1)];
+                // depending on how many characters were matched. If we have
+                // exceeded the number of results then fall back to the last element.
+                size_t max = results.size() - 1;
+                TokenType result = results[i <= max ? i : max];
 
-                // Skip any other potential whitespace
-                while (lexer->lookahead && (lexer->lookahead == ' ' || lexer->lookahead == '\t'))
-                    advance(lexer);
+                // Skip all whitespaces.
+                while (is_blank(lexer->lookahead))
+                    advance();
 
                 lexer->result_symbol = m_LastToken = result;
-
                 reset_active_modifiers();
-                return result;
+                return true;
             }
-        }
+
+            detached_modifier = find(m_DetachedModifiers.begin(), m_DetachedModifiers.end(),
+                                     lexer->lookahead);
+            ++i;
+            ++m_ParsedChars;
+        } while (detached_modifier != m_DetachedModifiers.end());
 
         // If we've only parsed one character and instantly failed then we might
         // be dealing with an attached modifier!
         if (m_ParsedChars == 1)
         {
             auto found_attached_modifier = m_AttachedModifiers.find(m_Current);
-
-            if (found_attached_modifier != m_AttachedModifiers.end() &&
-                !m_ActiveModifiers[(found_attached_modifier->second - BOLD_OPEN) / 2])
+            if (found_attached_modifier != m_AttachedModifiers.end()
+                && !m_ActiveModifiers[(found_attached_modifier->second - BOLD_OPEN) / 2])
             {
                 m_ActiveModifiers.set((found_attached_modifier->second - BOLD_OPEN) / 2);
                 lexer->result_symbol = m_LastToken = found_attached_modifier->second;
-                return m_LastToken;
+                return true;
             }
         }
 
-        return NONE;
+        return false;
     }
 
-    /*
+    /**
      * Checks for the existence of an attached modifier
-     * @param lexer - a pointer to the treesitter lexer
-     * @param behind - if true the parser will use m_Current instead of
-     * lexer->lookahead as its main lookahead source
      */
-    TokenType check_attached(TSLexer* lexer)
+    bool check_attached()
     {
         if (lexer->lookahead == ':')
         {
-            bool is_current_char_whitespace = !m_Current || std::iswspace(m_Current);
+            bool is_current_char_whitespace = !m_Current || iswspace(m_Current);
+            advance();
 
-            advance(lexer);
-
-            if (is_current_char_whitespace || std::iswspace(lexer->lookahead))
-                return NONE;
+            if (is_current_char_whitespace || iswspace(lexer->lookahead))
+                return false;
 
             lexer->result_symbol = m_LastToken = LINK_MODIFIER;
-            return m_LastToken;
+            return true;
         }
 
-        auto can_have_modifier = [&]()
-        {
-            return (!m_ActiveModifiers[(VERBATIM_OPEN - BOLD_OPEN) / 2] &&
-                    !m_ActiveModifiers[(INLINE_MATH_OPEN - BOLD_OPEN) / 2] &&
-                    !m_ActiveModifiers[(INLINE_MACRO_OPEN - BOLD_OPEN) / 2]);
+        auto can_have_modifier = [&]() {
+            return (!m_ActiveModifiers[(VERBATIM_OPEN - BOLD_OPEN) / 2]
+                    && !m_ActiveModifiers[(INLINE_MATH_OPEN - BOLD_OPEN) / 2]
+                    && !m_ActiveModifiers[(INLINE_MACRO_OPEN - BOLD_OPEN) / 2]);
         };
 
         if (lexer->lookahead == '|')
         {
-            advance(lexer);
-
+            advance();
 
             auto found_attached_modifier = m_AttachedModifiers.find(lexer->lookahead);
 
-            if (m_LastToken >= BOLD_OPEN && m_LastToken <= INLINE_MACRO_CLOSE &&
-                (m_LastToken % 2) == (BOLD_OPEN % 2))
+            if (m_LastToken >= BOLD_OPEN && m_LastToken <= INLINE_MACRO_CLOSE
+                && (m_LastToken % 2) == (BOLD_OPEN % 2))
             {
-                if (m_LastToken != VERBATIM_OPEN && m_LastToken != INLINE_MACRO_OPEN &&
-                    m_LastToken != INLINE_MATH_OPEN && !can_have_modifier())
-                    return NONE;
+                if (m_LastToken != VERBATIM_OPEN && m_LastToken != INLINE_MACRO_OPEN
+                    && m_LastToken != INLINE_MATH_OPEN && !can_have_modifier())
+                    return false;
 
                 lexer->result_symbol = m_LastToken = FREE_FORM_MODIFIER_OPEN;
-                return m_LastToken;
+                return true;
             }
             else if (found_attached_modifier != m_AttachedModifiers.end())
             {
-                if (
-                        !can_have_modifier() &&
-                        !(found_attached_modifier->second == VERBATIM_OPEN && m_ActiveModifiers[(VERBATIM_OPEN - BOLD_OPEN) / 2]) &&
-                        !(found_attached_modifier->second == INLINE_MATH_OPEN && m_ActiveModifiers[(INLINE_MATH_OPEN - BOLD_OPEN) / 2]) &&
-                        !(found_attached_modifier->second == INLINE_MACRO_OPEN && m_ActiveModifiers[(INLINE_MACRO_OPEN - BOLD_OPEN) / 2])
-                    )
-                        return NONE;
+                if (!can_have_modifier()
+                    && !(found_attached_modifier->second == VERBATIM_OPEN
+                         && m_ActiveModifiers[(VERBATIM_OPEN - BOLD_OPEN) / 2])
+                    && !(found_attached_modifier->second == INLINE_MATH_OPEN
+                         && m_ActiveModifiers[(INLINE_MATH_OPEN - BOLD_OPEN) / 2])
+                    && !(found_attached_modifier->second == INLINE_MACRO_OPEN
+                         && m_ActiveModifiers[(INLINE_MACRO_OPEN - BOLD_OPEN) / 2]))
+                    return false;
                 lexer->result_symbol = m_LastToken = FREE_FORM_MODIFIER_CLOSE;
-                return m_LastToken;
+                return true;
             }
 
-            return NONE;
+            return false;
         }
 
         auto found_attached_modifier = m_AttachedModifiers.find(lexer->lookahead);
 
         if (found_attached_modifier == m_AttachedModifiers.end())
-            return NONE;
+            return false;
 
         // First check for the existence of an opening attached modifier
-        if (std::iswspace(m_Current) ||
-            std::iswpunct(m_Current) && m_LastToken != FREE_FORM_MODIFIER_CLOSE || !m_Current)
+        if (iswspace(m_Current)
+            || (iswpunct(m_Current) && m_LastToken != FREE_FORM_MODIFIER_CLOSE)
+            || !m_Current)
         {
-            advance(lexer);
+            advance();
 
             // empty attached modifier
             if (lexer->lookahead == found_attached_modifier->first)
             {
                 while (lexer->lookahead == found_attached_modifier->first)
-                    advance(lexer);
-                return NONE;
+                    advance();
+                return false;
             }
 
             auto found_previous_attached_modifier = m_AttachedModifiers.find(m_Previous);
 
-            if (!std::iswspace(lexer->lookahead) &&
-                !m_ActiveModifiers[(found_attached_modifier->second - BOLD_OPEN) / 2])
+            if (!iswspace(lexer->lookahead)
+                && !m_ActiveModifiers[(found_attached_modifier->second - BOLD_OPEN) / 2]
+                && can_have_modifier())
             {
-                if (can_have_modifier())
-                {
-                    m_ActiveModifiers.set((found_attached_modifier->second - BOLD_OPEN) / 2);
-                    lexer->result_symbol = m_LastToken = found_attached_modifier->second;
-                    return m_LastToken;
-                }
+                m_ActiveModifiers.set((found_attached_modifier->second - BOLD_OPEN) / 2);
+                lexer->result_symbol = m_LastToken = found_attached_modifier->second;
+                return true;
             }
         }
         else
-            advance(lexer);
+            advance();
 
         if (lexer->lookahead == found_attached_modifier->first)
         {
             while (lexer->lookahead == found_attached_modifier->first)
-                advance(lexer);
-            return NONE;
+                advance();
+            return false;
         }
 
         auto found_next_attached_modifier = m_AttachedModifiers.find(lexer->lookahead);
@@ -1019,44 +961,39 @@ class Scanner
             m_ActiveModifiers.reset((found_attached_modifier->second - BOLD_OPEN) / 2);
             lexer->result_symbol = m_LastToken =
                 static_cast<TokenType>(found_attached_modifier->second + 1);
-            return m_LastToken;
+            return true;
         }
 
-        if (((!std::iswspace(m_Previous) || !m_Previous) &&
-             (std::iswspace(lexer->lookahead) || std::iswpunct(lexer->lookahead) ||
-              !lexer->lookahead)))
+        if ((!iswspace(m_Previous) || !m_Previous)
+            && (iswspace(lexer->lookahead) || iswpunct(lexer->lookahead) || !lexer->lookahead))
         {
             m_ActiveModifiers.reset((found_attached_modifier->second - BOLD_OPEN) / 2);
             lexer->result_symbol = m_LastToken =
                 static_cast<TokenType>(found_attached_modifier->second + 1);
-            return m_LastToken;
+            return true;
         }
 
-        return NONE;
+        return false;
     }
 
-    /*
-     * Attempts to parse a link location.
-     */
-    bool check_link_location(TSLexer* lexer)
+    /// Attempts to parse a link location.
+    bool check_link_location()
     {
         size_t count = 0;
 
-        switch (m_LastToken)
-        {
+        switch (m_LastToken) {
         case LINK_LOCATION_BEGIN:
             if (lexer->lookahead == ':')
             {
                 lexer->result_symbol = m_LastToken = LINK_FILE_BEGIN;
-                advance(lexer);
-                return !std::iswspace(lexer->lookahead);
+                advance();
+                return !iswspace(lexer->lookahead);
             }
             // since we have no break here, if we do not detect a beginning of a
             // file segment we fall through into this next case statement
         case INTERSECTING_MODIFIER:
         case LINK_FILE_END:
-            switch (lexer->lookahead)
-            {
+            switch (lexer->lookahead) {
             case '?':
                 lexer->result_symbol = m_LastToken = LINK_TARGET_WIKI;
                 break;
@@ -1066,13 +1003,11 @@ class Scanner
             case '/':
                 if (m_LastToken == LINK_FILE_END)
                     return false;
-
                 lexer->result_symbol = m_LastToken = LINK_TARGET_EXTERNAL_FILE;
                 break;
             case '@':
                 if (m_LastToken == LINK_FILE_END)
                     return false;
-
                 lexer->result_symbol = m_LastToken = LINK_TARGET_TIMESTAMP;
                 break;
             case '$':
@@ -1082,36 +1017,37 @@ class Scanner
                 lexer->result_symbol = m_LastToken = LINK_TARGET_FOOTNOTE;
                 break;
             case '*':
-                advance(lexer);
+                advance();
 
                 while (lexer->lookahead == '*')
                 {
                     ++count;
-                    advance(lexer);
+                    advance();
                 }
 
                 lexer->result_symbol = m_LastToken =
-                    static_cast<TokenType>(LINK_TARGET_HEADING1 + clamp(count, 0ull, 5ull));
+                    static_cast<TokenType>(LINK_TARGET_HEADING1 + (count <= 5 ? count : 5));
 
-                if (!std::iswspace(lexer->lookahead))
+                if (!iswspace(lexer->lookahead))
                     return false;
 
-                while (std::iswspace(lexer->lookahead))
-                    advance(lexer);
+                while (iswspace(lexer->lookahead))
+                    advance();
 
                 return true;
             default:
-                lexer->result_symbol = m_LastToken = std::iswdigit(lexer->lookahead) ? LINK_TARGET_LINE_NUMBER : LINK_TARGET_URL;
+                lexer->result_symbol = m_LastToken = iswdigit(lexer->lookahead) ?
+                                                     LINK_TARGET_LINE_NUMBER : LINK_TARGET_URL;
                 return true;
             }
 
-            advance(lexer);
+            advance();
 
-            if (!std::iswspace(lexer->lookahead))
+            if (!iswspace(lexer->lookahead))
                 return false;
 
-            while (std::iswspace(lexer->lookahead))
-                advance(lexer);
+            while (iswspace(lexer->lookahead))
+                advance();
 
             return true;
         case LINK_FILE_BEGIN:
@@ -1138,7 +1074,7 @@ class Scanner
                 if (lexer->lookahead == '$' && m_Current != ':')
                     return false;
 
-                advance(lexer);
+                advance();
             }
 
             lexer->result_symbol = m_LastToken = LINK_FILE_TEXT;
@@ -1147,179 +1083,182 @@ class Scanner
             if (lexer->lookahead == ':')
             {
                 lexer->result_symbol = m_LastToken = LINK_FILE_END;
-                advance(lexer);
-                return (lexer->lookahead == '}' || lexer->lookahead == '#' ||
-                        lexer->lookahead == '%' || lexer->lookahead == '$' ||
-                        lexer->lookahead == '^' || lexer->lookahead == '*' || std::iswdigit(lexer->lookahead));
+                advance();
+                switch (lexer->lookahead) {
+                case '}':
+                case '#':
+                case '%':
+                case '$':
+                case '^':
+                case '*':
+                    return true;
+                default:
+                    return iswdigit(lexer->lookahead);
+                }
             }
         default:
             return false;
         }
     }
 
-    /*
-     * Attempts to parse a detached modifier extension
-     */
-    bool check_detached_mod_extension(TSLexer* lexer)
+    /// Attempts to parse a detached modifier extension.
+    bool check_detached_mod_extension()
     {
         switch (m_LastToken) {
-            case DETACHED_MODIFIER_EXTENSION_BEGIN:
-            case MODIFIER_EXTENSION_DELIMITER:
-                switch (lexer->lookahead) {
-                    case '#':
-                        lexer->result_symbol = m_LastToken = PRIORITY;
-                        break;
-                    case '@':
-                        lexer->result_symbol = m_LastToken = TIMESTAMP;
-                        break;
-                    case ' ':
-                    case '\t':
-                    case '\v':
-                        lexer->result_symbol = m_LastToken = TODO_ITEM_UNDONE;
-                        break;
-                    case '-':
-                        lexer->result_symbol = m_LastToken = TODO_ITEM_PENDING;
-                        break;
-                    case 'x':
-                        lexer->result_symbol = m_LastToken = TODO_ITEM_DONE;
-                        break;
-                    case '=':
-                        lexer->result_symbol = m_LastToken = TODO_ITEM_ON_HOLD;
-                        break;
-                    case '_':
-                        lexer->result_symbol = m_LastToken = TODO_ITEM_CANCELLED;
-                        break;
-                    case '!':
-                        lexer->result_symbol = m_LastToken = TODO_ITEM_URGENT;
-                        break;
-                    case '?':
-                        lexer->result_symbol = m_LastToken = TODO_ITEM_UNCERTAIN;
-                        break;
-                    case '+':
-                        lexer->result_symbol = m_LastToken = TODO_ITEM_RECURRING;
-                        break;
-                    default:
-                        advance(lexer);
-                        return false;
-                }
-
-                advance(lexer);
-
-                while (std::iswspace(lexer->lookahead))
-                    advance(lexer);
-
-                return true;
-            case TIMESTAMP:
-            case PRIORITY:
-            case TODO_ITEM_RECURRING:
-                if (lexer->lookahead == ')')
-                {
-                    advance(lexer);
-                    lexer->result_symbol = m_LastToken = DETACHED_MODIFIER_EXTENSION_END;
-                    return true;
-                }
-                else if (lexer->lookahead == '|')
-                {
-                    advance(lexer);
-                    lexer->result_symbol = m_LastToken = MODIFIER_EXTENSION_DELIMITER;
-                    return true;
-                }
-
-                while (lexer->lookahead && lexer->lookahead != '|' && lexer->lookahead != ')')
-                    advance(lexer);
-
-                lexer->result_symbol = m_LastToken = (m_LastToken == TIMESTAMP || m_LastToken == TODO_ITEM_RECURRING) ? TIMESTAMP_DATA : PRIORITY_DATA;
-                return true;
-            case TODO_ITEM_UNDONE:
-            case TODO_ITEM_PENDING:
-            case TODO_ITEM_DONE:
-            case TODO_ITEM_ON_HOLD:
-            case TODO_ITEM_CANCELLED:
-            case TODO_ITEM_URGENT:
-            case TODO_ITEM_UNCERTAIN:
-            case TIMESTAMP_DATA:
-            case PRIORITY_DATA:
-                if (lexer->lookahead == ')')
-                {
-                    advance(lexer);
-                    lexer->result_symbol = m_LastToken = DETACHED_MODIFIER_EXTENSION_END;
-                    return true;
-                }
-                else if (lexer->lookahead == '|' && m_AttachedModifiers.find(m_Current) == m_AttachedModifiers.end())
-                {
-                    advance(lexer);
-
-                    lexer->result_symbol = m_LastToken = MODIFIER_EXTENSION_DELIMITER;
-                    return true;
-                }
-
-                return false;
-            default:
-                if (m_LastToken < HEADING1 || m_LastToken > MULTI_TABLE_CELL_SUFFIX)
-                    return false;
-
-                if (lexer->lookahead == '(')
-                {
-                    advance(lexer);
-                    lexer->result_symbol = m_LastToken = DETACHED_MODIFIER_EXTENSION_BEGIN;
-                    return true;
-                }
-                else if (lexer->lookahead == ')')
-                {
-                    advance(lexer);
-                    lexer->result_symbol = m_LastToken = DETACHED_MODIFIER_EXTENSION_END;
-                    return true;
-                }
+        case DETACHED_MODIFIER_EXTENSION_BEGIN:
+        case MODIFIER_EXTENSION_DELIMITER:
+            switch (lexer->lookahead) {
+            case '#':
+                lexer->result_symbol = m_LastToken = PRIORITY;
                 break;
+            case '@':
+                lexer->result_symbol = m_LastToken = TIMESTAMP;
+                break;
+            case ' ':
+            case '\t':
+            case '\v':
+                lexer->result_symbol = m_LastToken = TODO_ITEM_UNDONE;
+                break;
+            case '-':
+                lexer->result_symbol = m_LastToken = TODO_ITEM_PENDING;
+                break;
+            case 'x':
+                lexer->result_symbol = m_LastToken = TODO_ITEM_DONE;
+                break;
+            case '=':
+                lexer->result_symbol = m_LastToken = TODO_ITEM_ON_HOLD;
+                break;
+            case '_':
+                lexer->result_symbol = m_LastToken = TODO_ITEM_CANCELLED;
+                break;
+            case '!':
+                lexer->result_symbol = m_LastToken = TODO_ITEM_URGENT;
+                break;
+            case '?':
+                lexer->result_symbol = m_LastToken = TODO_ITEM_UNCERTAIN;
+                break;
+            case '+':
+                lexer->result_symbol = m_LastToken = TODO_ITEM_RECURRING;
+                break;
+            default:
+                advance();
+                return false;
+            }
+
+            advance();
+
+            while (iswspace(lexer->lookahead))
+                advance();
+
+            return true;
+        case TIMESTAMP:
+        case PRIORITY:
+        case TODO_ITEM_RECURRING:
+            switch (lexer->lookahead) {
+            case ')':
+                advance();
+                lexer->result_symbol = m_LastToken = DETACHED_MODIFIER_EXTENSION_END;
+                return true;
+            case '|':
+                advance();
+                lexer->result_symbol = m_LastToken = MODIFIER_EXTENSION_DELIMITER;
+                return true;
+            }
+
+            while (lexer->lookahead && lexer->lookahead != '|' && lexer->lookahead != ')')
+                advance();
+
+            lexer->result_symbol = m_LastToken =
+                (m_LastToken == TIMESTAMP || m_LastToken == TODO_ITEM_RECURRING) ?
+                    TIMESTAMP_DATA : PRIORITY_DATA;
+
+            return true;
+        case TODO_ITEM_UNDONE:
+        case TODO_ITEM_PENDING:
+        case TODO_ITEM_DONE:
+        case TODO_ITEM_ON_HOLD:
+        case TODO_ITEM_CANCELLED:
+        case TODO_ITEM_URGENT:
+        case TODO_ITEM_UNCERTAIN:
+        case TIMESTAMP_DATA:
+        case PRIORITY_DATA:
+            switch (lexer->lookahead) {
+            case ')':
+                advance();
+                lexer->result_symbol = m_LastToken = DETACHED_MODIFIER_EXTENSION_END;
+                return true;
+            case '|':
+                if (m_AttachedModifiers.find(m_Current) == m_AttachedModifiers.end())
+                {
+                    advance();
+                    lexer->result_symbol = m_LastToken = MODIFIER_EXTENSION_DELIMITER;
+                    return true;
+                }
+            }
+            return false;
+        default:
+            if (m_LastToken < HEADING1 || m_LastToken > MULTI_TABLE_CELL_SUFFIX)
+                return false;
+
+            switch (lexer->lookahead) {
+            case '(':
+                advance();
+                lexer->result_symbol = m_LastToken = DETACHED_MODIFIER_EXTENSION_BEGIN;
+                return true;
+            case ')':
+                advance();
+                lexer->result_symbol = m_LastToken = DETACHED_MODIFIER_EXTENSION_END;
+                return true;
+            }
         }
 
         return false;
     }
 
-    /*
+    /**
      * Simply parses any word (segment containing consecutive non-whitespace
-     * characters). If in a tag parse_text parses
-     * till a newline is encountered
+     * characters). If in a tag parse_text parses till a newline is encountered.
      */
-    bool parse_text(TSLexer* lexer)
+    bool parse_text()
     {
         if (m_TagContext == TagType::IN_VERBATIM_TAG)
         {
-            while (lexer->lookahead && !is_newline(lexer->lookahead))
-                advance(lexer);
-
+            while (!is_newline(lexer->lookahead))
+                advance();
             lexer->result_symbol = m_LastToken = WORD;
             return true;
         }
 
         if (((char)m_TagContext % 2) == 0 && lexer->lookahead == '.')
         {
-            advance(lexer);
+            advance();
             lexer->result_symbol = m_LastToken = TAG_DELIMITER;
             return true;
         }
 
-        if (is_newline(lexer->lookahead) || !lexer->lookahead)
+        if (is_newline(lexer->lookahead))
         {
             lexer->result_symbol = m_LastToken = WORD;
             return true;
         }
 
-        if (lexer->lookahead == ' ' || lexer->lookahead == '\t')
+        if (is_blank(lexer->lookahead))
         {
             do
-                advance(lexer);
-            while (lexer->lookahead && std::iswblank(lexer->lookahead));
+                advance();
+            while (is_blank(lexer->lookahead));
 
             if (lexer->lookahead == ':')
             {
-                advance(lexer);
-                if (lexer->lookahead && std::iswblank(lexer->lookahead))
+                advance();
+                if (is_blank(lexer->lookahead))
                 {
-                    advance(lexer);
+                    advance();
                     lexer->result_symbol = m_LastToken = INTERSECTING_MODIFIER;
                     return true;
-                } else {
+                }
+                else
+                {
                     lexer->result_symbol = m_LastToken = WORD;
                     return true;
                 }
@@ -1329,75 +1268,37 @@ class Scanner
             return true;
         }
 
-        const TokenType resulting_symbol =
-            (bool)std::iswupper(lexer->lookahead) ? CAPITALIZED_WORD : WORD;
+        const TokenType resulting_symbol = iswupper(lexer->lookahead) ?
+                                           CAPITALIZED_WORD : WORD;
 
         do
         {
-            if (lexer->lookahead == ':' || lexer->lookahead == '|' || lexer->lookahead == '=' || lexer->lookahead == '~' ||
-                (m_AttachedModifiers.find(lexer->lookahead) != m_AttachedModifiers.end()) ||
-                (lexer->lookahead == '<' || lexer->lookahead == '>' || lexer->lookahead == '[' ||
-                 lexer->lookahead == ']' || lexer->lookahead == '{' || lexer->lookahead == '}') ||
-                lexer->lookahead == '\\' || lexer->lookahead == '(' || lexer->lookahead == ')' ||
-                (((char)m_TagContext % 2 == 0) ? (lexer->lookahead == '.') : false))
+            bool _break = false;
+            switch (lexer->lookahead)
+            case ':': case '|': case '=': case '~': case '\\':
+            case '<': case '>':
+            case '[': case ']':
+            case '{': case '}':
+            case '(': case ')':
+                _break = true;
+
+            if (_break
+                || m_AttachedModifiers.find(lexer->lookahead) != m_AttachedModifiers.end()
+                || ((char)m_TagContext % 2 == 0 && lexer->lookahead == '.'))
                 break;
             else
-                advance(lexer);
-        } while (lexer->lookahead && !std::iswspace(lexer->lookahead) && lexer->lookahead != '\\');
+                advance();
+        } while (lexer->lookahead && !iswspace(lexer->lookahead) && lexer->lookahead != '\\');
 
         lexer->result_symbol = m_LastToken = resulting_symbol;
         return true;
     }
 
-    template <typename T, typename Comp>
-    T clamp(T value, Comp min, Comp max)
-    {
-        return value < min ? min : (value > max ? max : value);
-    }
-
     inline void reset_active_modifiers() { m_ActiveModifiers.reset(); }
 
-    inline bool is_newline(int32_t c) { return c == '\n' || c == '\r'; }
+    inline bool is_newline(int32_t c) { return !c || c == '\n' || c == '\r'; }
 
-   private:
-    // Stores the current char rather than the next char
-    int32_t m_Previous = 0, m_Current = 0;
-
-    TagType m_TagContext = TagType::NONE;
-    size_t m_TagLevel = 0;
-
-    bool m_InLinkLocation = false;
-
-    // The last matched token type (used to detect things like todo items
-    // which require an unordered list prefix beforehand)
-    TokenType m_LastToken = NONE;
-
-    // Used for lookback
-    size_t m_ParsedChars = 0;
-
-   private:
-    const std::array<int32_t, 12> m_DetachedModifiers = {'*', '-', '>', '%', '=', '~',
-                                                         '$', '_', '^', '&', '<', ':'};
-    const std::unordered_map<int32_t, TokenType> m_DetachedModifierExtensions = {
-        {'#', PRIORITY},
-        {'@', TIMESTAMP},
-        {' ', TODO_ITEM_UNDONE},
-        {'-', TODO_ITEM_PENDING},
-        {'x', TODO_ITEM_DONE},
-        {'=', TODO_ITEM_ON_HOLD},
-        {'_', TODO_ITEM_CANCELLED},
-        {'!', TODO_ITEM_URGENT},
-        {'+', TODO_ITEM_RECURRING},
-        {'?', TODO_ITEM_UNCERTAIN},
-    };
-    const std::unordered_map<int32_t, TokenType> m_AttachedModifiers = {
-        {'*', BOLD_OPEN},        {'/', ITALIC_OPEN},    {'-', STRIKETHROUGH_OPEN},
-        {'_', UNDERLINE_OPEN},   {'!', SPOILER_OPEN},   {'`', VERBATIM_OPEN},
-        {'^', SUPERSCRIPT_OPEN}, {',', SUBSCRIPT_OPEN}, {'%', INLINE_COMMENT_OPEN},
-        {'$', INLINE_MATH_OPEN}, {'&', INLINE_MACRO_OPEN},
-    };
-
-    std::bitset<((INLINE_MACRO_OPEN - BOLD_OPEN) / 2) + 1> m_ActiveModifiers;
+    inline bool is_blank(int32_t c) { return c && std::iswblank(c); }
 };
 
 extern "C"
@@ -1416,38 +1317,33 @@ extern "C"
                                                 TSLexer* lexer,
                                                 const bool* valid_symbols)
     {
-        return static_cast<Scanner*>(payload)->scan(lexer, valid_symbols);
+        Scanner* scanner = static_cast<Scanner*>(payload);
+        scanner->lexer = lexer;
+        return scanner->scan(valid_symbols);
     }
 
     unsigned tree_sitter_norg_external_scanner_serialize(void* payload, char* buffer)
     {
         Scanner* scanner = static_cast<Scanner*>(payload);
 
-        const auto& tag_level = scanner->get_tag_level();
-        const auto& tag_context = scanner->get_tag_context();
-        const auto& in_link_location = scanner->get_in_link_location();
-        const auto& last_token = scanner->get_last_token();
-        const auto& current = scanner->get_current_char();
-        const auto& active_modifiers = scanner->get_active_modifiers();
-
-        if (8 + active_modifiers.size() >= TREE_SITTER_SERIALIZATION_BUFFER_SIZE)
+        if (8 + scanner->m_ActiveModifiers.size() >= TREE_SITTER_SERIALIZATION_BUFFER_SIZE)
             return 0;
 
-        buffer[0] = last_token;
-        buffer[1] = tag_level;
-        buffer[2] = (char)tag_context;
-        buffer[3] = in_link_location;
+        buffer[0] = scanner->m_LastToken;
+        buffer[1] = scanner->m_TagLevel;
+        buffer[2] = (char)scanner->m_TagContext;
+        buffer[3] = scanner->m_InLinkLocation;
 
         // Copy 4 bytes from int32_t to buffer 2 to 6 positions.
-        std::memcpy(buffer + 4, &current, 4);
+        memcpy(buffer + 4, &scanner->m_Current, 4);
 
         // Serialize the attached modifier bitset into the char array
         // We cast it down to a uint32_t because we genuinely won't be using any
         // more than that.
-        for (int i = 0; i < active_modifiers.size(); i++)
-            buffer[8 + i] = active_modifiers[i];
+        for (int i = 0; i < scanner->m_ActiveModifiers.size(); ++i)
+            buffer[8 + i] = scanner->m_ActiveModifiers[i];
 
-        return 8 + active_modifiers.size();
+        return 8 + scanner->m_ActiveModifiers.size();
     }
 
     void tree_sitter_norg_external_scanner_deserialize(void* payload,
@@ -1456,32 +1352,25 @@ extern "C"
     {
         Scanner* scanner = static_cast<Scanner*>(payload);
 
-        auto& tag_level = scanner->get_tag_level();
-        auto& tag_context = scanner->get_tag_context();
-        auto& in_link_location = scanner->get_in_link_location();
-        auto& last_token = scanner->get_last_token();
-        auto& current = scanner->get_current_char();
-        auto& active_modifiers = scanner->get_active_modifiers();
-
         if (length == 0)
         {
-            tag_level = 0;
-            tag_context = TagType::NONE;
-            in_link_location = false;
-            last_token = NONE;
-            current = 0;
-            active_modifiers = 0;
+            scanner->m_TagLevel = 0;
+            scanner->m_TagContext = TagType::NONE;
+            scanner->m_InLinkLocation = false;
+            scanner->m_LastToken = NONE;
+            scanner->m_Current = 0;
+            scanner->m_ActiveModifiers = 0;
             return;
         }
 
-        last_token = (TokenType)buffer[0];
-        tag_level = (size_t)buffer[1];
-        tag_context = (TagType)buffer[2];
-        in_link_location = (bool)buffer[3];
+        scanner->m_LastToken = (TokenType)buffer[0];
+        scanner->m_TagLevel = (size_t)buffer[1];
+        scanner->m_TagContext = (TagType)buffer[2];
+        scanner->m_InLinkLocation = (bool)buffer[3];
 
-        std::memcpy(&current, buffer + 4, 4);
+        memcpy(&scanner->m_Current, buffer + 4, 4);
 
-        for (int i = 0; i < active_modifiers.size(); i++)
-            active_modifiers[i] = buffer[8 + i];
+        for (int i = 0; i < scanner->m_ActiveModifiers.size(); ++i)
+            scanner->m_ActiveModifiers[i] = buffer[8 + i];
     }
 }


### PR DESCRIPTION
I became interested in how the neorg treesitter parser works, and it so happened
that I refactored it a bit.

Added `using namespace std`. Since we use only std it is safe.

Converted `Scanner` to struct, since no one will ever use this class, so no need
to mess with getters and setters. Besides, getters returned raw links, it is the
same as get direct access to the memory..

Deleted `|` operators overloading. We never add any elements into TokenType
vectors after creating them. But what we do, is create a vector for one element.
Then add another one. Vector allocate memory for 2 elements, and copy first
element into new memory. And we do this six times for every `check_detached`
function call just to construct vector that always the same.

Added `lexer` attribute into `Scanner` class for convenience: to not pass it
every function.

Refactored `check_detached` function.  Removed template. Converted `expected`
array into single element, since we always pass only one expected element.
Deleted `terminate_at` parameter: it's do nothing, looks like it remained from
the past.
Returned type is now `bool`, since we only check that returned `TokenType` is
not `NONE`.

Improve check for `end` token for tags.

All tests are passed.