### PR TITLE
fix(bindings): add external scanner

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -9,7 +9,7 @@
       "sources": [
         "bindings/node/binding.cc",
         "src/parser.c",
-        # If your language uses an external scanner, add it here.
+        "src/scanner.cc",
       ],
       "cflags_c": [
         "-std=c99",

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -22,10 +22,6 @@ fn main() {
     c_config.compile("parser");
     println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
 
-    // If your language uses an external scanner written in C++,
-    // then include this block of code:
-
-    /*
     let mut cpp_config = cc::Build::new();
     cpp_config.cpp(true);
     cpp_config.include(&src_dir);
@@ -36,5 +32,4 @@ fn main() {
     cpp_config.file(&scanner_path);
     cpp_config.compile("scanner");
     println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-    */
 }


### PR DESCRIPTION
The external scanner was not properly registered in the bindings causing it to not be compiled and the bindings themselves to not properly compile or link.