### PR TITLE
feat: add support for building with swift package manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 node_modules
 build
+.build
+.swiftpm
 Cargo.lock
 package-lock.json
 yarn.lock

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,35 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "TreeSitterNorg",
+    products: [
+        .library(name: "TreeSitterNorg", targets: ["TreeSitterNorg"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(name: "TreeSitterNorg",
+                path: ".",
+                exclude: [
+                    "binding.gyp",
+                    "bindings",
+                    "Cargo.toml",
+                    "default.nix",
+                    "flake.nix",
+                    "flake.lock",
+                    "grammar.js",
+                    "LICENSE",
+                    "package.json",
+                    "README.md",
+                    "src/grammar.json",
+                    "src/node-types.json",
+                ],
+                sources: [
+                    "src/parser.c",
+                    "src/scanner.cc"
+                ],
+                publicHeadersPath: "bindings/swift",
+                cSettings: [.headerSearchPath("src")]),
+    ],
+    cxxLanguageStandard: .cxx14
+)

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,6 @@ let package = Package(
                 path: ".",
                 exclude: [
                     "binding.gyp",
-                    "bindings",
                     "Cargo.toml",
                     "default.nix",
                     "flake.nix",
@@ -23,6 +22,7 @@ let package = Package(
                     "README.md",
                     "src/grammar.json",
                     "src/node-types.json",
+                    "test",
                 ],
                 sources: [
                     "src/parser.c",

--- a/bindings/swift/TreeSitterNorg/norg.h
+++ b/bindings/swift/TreeSitterNorg/norg.h
@@ -1,0 +1,16 @@
+#ifndef TREE_SITTER_NORG_H_
+#define TREE_SITTER_NORG_H_
+
+typedef struct TSLanguage TSLanguage;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern TSLanguage *tree_sitter_norg();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_NORG_H_


### PR DESCRIPTION
I'm in the process of building out an iOS/macOS/visionOS editor for `.norg` documents. In order to keep current with language features, I'm using the tree-sitter parser as a base. I'm using the [SwiftTreeSitter](https://github.com/ChimeHQ/SwiftTreeSitter) library to do so. To use this repo, I needed to add support for building with the Swift Package Manager. This PR adds the required code.

Similar work can be seen in the [tree-sitter-java](https://github.com/tree-sitter/tree-sitter-java/pull/113) repo.

## Testing

You can test the changes by [installing Swift](https://www.swift.org/download/) and executing the following command from the `tree-sitter-norg` directory:

```
swift build
```